### PR TITLE
Fix full metadata access

### DIFF
--- a/src/AssemblyGenerator.Assemblies.cs
+++ b/src/AssemblyGenerator.Assemblies.cs
@@ -62,7 +62,7 @@ namespace Lokad.ILPack
                 assemblyName.Version,
                 GetString(assemblyName.CultureName),
                 GetBlob(hashOrToken),
-                _assemblyNameFlagsConvert(assemblyName.Flags),
+                ConvertReferencedAssemblyNameFlags(assemblyName.Flags),
                 default(BlobHandle)); // Null is allowed
 
             _assemblyReferenceHandles.Add(uniqueName, handle);

--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -56,13 +56,14 @@ namespace Lokad.ILPack
 
             var name = _currentAssembly.GetName();
 
+            var assemblyPublicKey = name.GetPublicKey();
             var assemblyHandle = _metadataBuilder.AddAssembly(
                 GetString(name.Name),
                 name.Version,
                 GetString(name.CultureName),
-                GetBlob(name.GetPublicKey()),
-                _assemblyNameFlagsConvert(name.Flags),
-                _assemblyHashAlgorithmConvert(name.HashAlgorithm));
+                assemblyPublicKey.Length > 0 ? GetBlob(name.GetPublicKey()) : default(BlobHandle),
+                ConvertGeneratedAssemblyNameFlags(name),
+                ConvertAssemblyHashAlgorithm(name.HashAlgorithm));
 
             // Add "<Module>" type definition *before* any type definition.
             //


### PR DESCRIPTION
Issue #11 was caused when referenced runtime assemblies have `PublicKey` flag. This commit extends existing unit tests with forced metadata access to replicate this issue for all unit tests. Also, this commit improves the codebase by separating generated and referenced assembly name flag mapping to able apply different logic and eventually fix this issue.

Fixes: #11