### PR TITLE
Fix cyclic dependency and user string handling

### DIFF
--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 
@@ -12,35 +11,34 @@ namespace Lokad.ILPack
         public void CreateCustomAttributes(EntityHandle parent, IEnumerable<CustomAttributeData> attributes)
         {
             // TODO: implement support for custom attributes
-            return;
 
-            foreach (var attr in attributes)
-            {
-                var type = attr.AttributeType;
-                GetOrCreateType(type); // create type
+            //foreach (var attr in attributes)
+            //{
+            //    var type = attr.AttributeType;
+            //    GetTypeHandle(type); // create type
 
-                var args = attr.ConstructorArguments;
-                var text = string.Join(",", args.Select(x => $"\"{x.Value}"));
+            //    var args = attr.ConstructorArguments;
+            //    var text = string.Join(",", args.Select(x => $"\"{x.Value}"));
 
-                /*
-                var namedArgs = attr.NamedArguments;
-                var namedText = string.Join(", ", namedArgs
-                    .Where(x => !string.IsNullOrEmpty(x.TypedValue.Value.ToString()))
-                    .Select(x =>
-                {
-                    return $"{x.MemberName}=\"{x.TypedValue.Value}\"";
-                }));
+            //    /*
+            //    var namedArgs = attr.NamedArguments;
+            //    var namedText = string.Join(", ", namedArgs
+            //        .Where(x => !string.IsNullOrEmpty(x.TypedValue.Value.ToString()))
+            //        .Select(x =>
+            //    {
+            //        return $"{x.MemberName}=\"{x.TypedValue.Value}\"";
+            //    }));
 
-                if (!string.IsNullOrEmpty(namedText))
-                    text += $", {namedText}";
-                */
-                var ctor = GetTypeConstructor(type);
-                if (ctor != null)
-                {
-                    //Console.WriteLine(text);
-                    _metadataBuilder.AddCustomAttribute(parent, ctor.Value, GetCustomAttributeValueFromString(text));
-                }
-            }
+            //    if (!string.IsNullOrEmpty(namedText))
+            //        text += $", {namedText}";
+            //    */
+            //    var ctor = GetTypeConstructor(type);
+            //    if (ctor != null)
+            //    {
+            //        //Console.WriteLine(text);
+            //        _metadata.Builder.AddCustomAttribute(parent, ctor.Value, GetCustomAttributeValueFromString(text));
+            //    }
+            //}
         }
     }
 }

--- a/src/AssemblyGenerator.Constructors.cs
+++ b/src/AssemblyGenerator.Constructors.cs
@@ -1,129 +1,50 @@
-﻿using System;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Metadata;
 using Lokad.ILPack.IL;
 
 namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
-        internal BlobHandle GetConstructorSignature(ConstructorInfo constructorInfo)
+        private void CreateConstructor(ConstructorInfo ctor)
         {
-            var parameters = constructorInfo.GetParameters();
-            var countParameters = parameters.Length;
-
-            var blob = BuildSignature(x => x.MethodSignature(
-                    ConvertCallingConvention(constructorInfo.CallingConvention),
-                    isInstanceMethod: !constructorInfo.IsStatic)
-                .Parameters(
-                    countParameters,
-                    r => r.Void(),
-                    p =>
-                    {
-                        foreach (var par in parameters)
-                        {
-                            var parEncoder = p.AddParameter();
-                            parEncoder.Type().FromSystemType(par.ParameterType, this);
-                        }
-                    }));
-            return GetBlob(blob);
-        }
-
-        internal EntityHandle? GetTypeConstructor(Type type)
-        {
-            return CreateConstructorForReferencedType(type);
-
-            //_ctorHandles.TryGetValue(type, out var collection);
-            //return collection?.First();
-        }
-
-        internal MemberReferenceHandle CreateConstructorForReferencedType(Type type)
-        {
-            var ctors = type.GetConstructors();
-            var typeHandle = GetOrCreateType(type);
-
-            if (ctors.Length == 0)
+            if (!_metadata.TryGetConstructorDefinition(ctor, out var metadata))
             {
-                return default(MemberReferenceHandle);
+                ThrowMetadataIsNotReserved("Constructor", ctor);
             }
 
-            var handles = new MemberReferenceHandle[ctors.Length];
-            for (var i = 0; i < ctors.Length; i++)
-            {
-                var ctor = ctors[i];
+            EnsureMetadataWasNotEmitted(metadata, ctor);
 
-                if (_ctorRefHandles.TryGetValue(ctor, out var ctorDef))
-                {
-                    handles[i] = ctorDef;
-                    continue;
-                }
+            var parameters = CreateParameters(ctor.GetParameters());
+            var bodyOffset = _metadata.ILBuilder.Count;
 
-                var signature = GetConstructorSignature(ctor);
-                ctorDef = _metadataBuilder.AddMemberReference(
-                    typeHandle, GetString(ctor.Name), signature);
-
-                // HACK: [vermorel] recursive insertions can happen
-                //if(!_ctorRefHandles.ContainsKey(ctor))
-                _ctorRefHandles.Add(ctor, ctorDef);
-
-                handles[i] = ctorDef;
-
-                CreateCustomAttributes(ctorDef, ctor.GetCustomAttributesData());
-            }
-
-            return handles.First();
-        }
-
-        internal MethodDefinitionHandle CreateConstructor(ConstructorInfo constructorInfo)
-        {
-            if (_ctorDefHandles.TryGetValue(constructorInfo, out var constructorDef))
-            {
-                return constructorDef;
-            }
-
-            var parameters = CreateParameters(constructorInfo.GetParameters());
-            var bodyOffset = _ilBuilder.Count;
-
-            var body = constructorInfo.GetMethodBody();
+            var body = ctor.GetMethodBody();
             if (body != null)
             {
-                var methodBodyWriter = new MethodBodyStreamWriter(_ilBuilder, GetString, _typeHandles, _ctorRefHandles,
-                    _fieldHandles, _methodsHandles);
+                var methodBodyWriter = new MethodBodyStreamWriter(_metadata);
 
                 // bodyOffset can be aligned during serialization. So, override the correct offset.
-                bodyOffset = methodBodyWriter.AddMethodBody(constructorInfo);
+                bodyOffset = methodBodyWriter.AddMethodBody(ctor);
             }
 
-            var ctorDef = _metadataBuilder.AddMethodDefinition(
-                constructorInfo.Attributes,
-                constructorInfo.MethodImplementationFlags,
-                GetString(constructorInfo.Name),
-                GetConstructorSignature(constructorInfo),
+            var handle = _metadata.Builder.AddMethodDefinition(
+                ctor.Attributes,
+                ctor.MethodImplementationFlags,
+                _metadata.GetOrAddString(ctor.Name),
+                _metadata.GetConstructorSignature(ctor),
                 bodyOffset,
                 parameters);
 
-            _ctorDefHandles.Add(constructorInfo, ctorDef);
-
-            return ctorDef;
+            VerifyEmittedHandle(metadata, handle);
+            metadata.MarkAsEmitted();
         }
 
-        internal MethodDefinitionHandle CreateConstructors(ConstructorInfo[] constructors)
+        private void CreateConstructors(IEnumerable<ConstructorInfo> constructors)
         {
-            if (constructors.Length == 0)
+            foreach (var ctor in constructors)
             {
-                return default(MethodDefinitionHandle);
+                CreateConstructor(ctor);
             }
-
-            var handles = new MethodDefinitionHandle[constructors.Length];
-            for (var i = 0; i < constructors.Length; i++)
-            {
-                var ctor = constructors[i];
-                var ctorDef = CreateConstructor(ctor);
-                handles[i] = ctorDef;
-            }
-
-            return handles.First();
         }
     }
 }

--- a/src/AssemblyGenerator.Helpers.cs
+++ b/src/AssemblyGenerator.Helpers.cs
@@ -1,44 +1,16 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
+using Lokad.ILPack.Metadata;
 using CfgAssemblyHashAlgorithm = System.Configuration.Assemblies.AssemblyHashAlgorithm;
 
 namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
-        private AssemblyFlags ConvertAssemblyNameFlags(AssemblyNameFlags flags)
+        private static AssemblyFlags ConvertGeneratedAssemblyNameFlags(AssemblyName asmName)
         {
-            var result = (AssemblyFlags) 0;
-
-            if (flags.HasFlag(AssemblyNameFlags.PublicKey))
-            {
-                result |= AssemblyFlags.PublicKey;
-            }
-
-            if (flags.HasFlag(AssemblyNameFlags.Retargetable))
-            {
-                result |= AssemblyFlags.Retargetable;
-            }
-
-            // No, it's not a typo. Microsoft decided to put "exact opposite of the meaning" for this flag.
-            if (flags.HasFlag(AssemblyNameFlags.EnableJITcompileOptimizer))
-            {
-                result |= AssemblyFlags.DisableJitCompileOptimizer;
-            }
-
-            if (flags.HasFlag(AssemblyNameFlags.EnableJITcompileTracking))
-            {
-                result |= AssemblyFlags.EnableJitCompileTracking;
-            }
-
-            return result;
-        }
-
-        private AssemblyFlags ConvertGeneratedAssemblyNameFlags(AssemblyName asmName)
-        {
-            var result = ConvertAssemblyNameFlags(asmName.Flags);
+            var result = MetadataHelper.ConvertAssemblyNameFlags(asmName.Flags);
 
             // If there is no public key, unset PublicKey flag.
             if (result.HasFlag(AssemblyFlags.PublicKey) && asmName.GetPublicKey().Length == 0)
@@ -49,118 +21,47 @@ namespace Lokad.ILPack
             return result;
         }
 
-        private AssemblyFlags ConvertReferencedAssemblyNameFlags(AssemblyNameFlags flags)
-        {
-            var result = ConvertAssemblyNameFlags(flags);
-
-            // TODO: [osman] Referenced runtime assemblies don't have PublicKey flag.
-            // How should we handle an assembly which doesn't have a strong name?
-            result &= ~AssemblyFlags.PublicKey;
-
-            return result;
-        }
-
-        private AssemblyHashAlgorithm ConvertAssemblyHashAlgorithm(CfgAssemblyHashAlgorithm alg)
+        private static AssemblyHashAlgorithm ConvertAssemblyHashAlgorithm(CfgAssemblyHashAlgorithm alg)
         {
             return (AssemblyHashAlgorithm) alg;
-        }
-
-        private SignatureCallingConvention ConvertCallingConvention(CallingConventions callingConvention)
-        {
-            // TODO: incorrect / draft implementation
-            // See https://stackoverflow.com/questions/54632913/how-to-convert-callingconventions-into-signaturecallingconvention
-
-            //if (callingConvention.HasFlag(CallingConventions.Any))
-            //    result |= SignatureCallingConvention.StdCall | SignatureCallingConvention.VarArgs;
-
-            //if (callingConvention.HasFlag(CallingConventions.ExplicitThis))
-            //    result = 0x40;
-
-            //else if (callingConvention.HasFlag(CallingConventions.HasThis))
-            //    result = 0x20;
-
-            SignatureCallingConvention result = 0;
-
-            //if(callingConvention.HasFlag(CallingConventions.HasThis))
-            //    result |= SignatureCallingConvention.ThisCall;
-
-            //if (callingConvention.HasFlag(CallingConventions.Standard))
-            //    result |= SignatureCallingConvention.StdCall;
-
-            if (callingConvention.HasFlag(CallingConventions.VarArgs))
-            {
-                result |= SignatureCallingConvention.VarArgs;
-            }
-
-            return result;
-
-            /*
-            var result = SignatureCallingConvention.Default;
-            
-            if (callingConvention.HasFlag(CallingConventions.Any))
-                result |= SignatureCallingConvention.StdCall | SignatureCallingConvention.VarArgs;
-
-            if (callingConvention.HasFlag(CallingConventions.ExplicitThis))
-                throw new Exception("Unknown Calling Convention (ExplicitThis)");
-
-            if (callingConvention.HasFlag(CallingConventions.HasThis))
-                result |= SignatureCallingConvention.ThisCall;
-
-            if (callingConvention.HasFlag(CallingConventions.Standard))
-                result |= SignatureCallingConvention.StdCall;
-
-            if (callingConvention.HasFlag(CallingConventions.VarArgs))
-                result |= SignatureCallingConvention.VarArgs;
-
-            return result;
-            */
-        }
-
-        private BlobBuilder BuildSignature(Action<BlobEncoder> action)
-        {
-            var builder = new BlobBuilder();
-            action(new BlobEncoder(builder));
-            return builder;
-        }
-
-        private BlobBuilder BuildSignature(BlobBuilder builder, Action<BlobEncoder> action)
-        {
-            action(new BlobEncoder(builder));
-            return builder;
-        }
-
-        private StringHandle GetString(string str)
-        {
-            return _metadataBuilder.GetOrAddString(str);
-        }
-
-        private BlobHandle GetBlob(byte[] bytes)
-        {
-            return _metadataBuilder.GetOrAddBlob(bytes);
         }
 
         private BlobHandle GetCustomAttributeValueFromString(string str)
         {
             if (str == null)
             {
-                return default(BlobHandle);
+                return default;
             }
 
             var builder = new BlobBuilder();
             builder.WriteBytes(new byte[] {0x01, 0x00}); // "prolog"
             builder.WriteUTF8(str);
 
-            return GetBlob(builder);
+            return _metadata.Builder.GetOrAddBlob(builder);
         }
 
-        private BlobHandle GetBlob(BlobBuilder builder)
+        private static void EnsureMetadataWasNotEmitted<TEntity, THandle>(DefinitionMetadata<TEntity, THandle> metadata,
+            TEntity entity)
         {
-            return _metadataBuilder.GetOrAddBlob(builder);
+            if (metadata.IsEmitted)
+            {
+                throw new InvalidOperationException($"Entity metadata was already emitted before: {entity}");
+            }
         }
 
-        private GuidHandle GetGuid(Guid guid)
+        private static void ThrowMetadataIsNotReserved<TEntity>(string entityFriendlyName, TEntity entity)
         {
-            return _metadataBuilder.GetOrAddGuid(guid);
+            throw new InvalidOperationException(
+                $"{entityFriendlyName} metadata should be reserved before emitting metadata: {entity}");
+        }
+
+        private static void VerifyEmittedHandle<TEntity, THandle>(DefinitionMetadata<TEntity, THandle> metadata,
+            THandle handle)
+        {
+            if (!metadata.Handle.Equals(handle))
+            {
+                throw new InvalidOperationException("Reserved and emitted metadata handles are different.");
+            }
         }
     }
 }

--- a/src/AssemblyGenerator.Modules.cs
+++ b/src/AssemblyGenerator.Modules.cs
@@ -1,20 +1,20 @@
-﻿using System.Reflection;
-using System.Reflection.Metadata;
+﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
-        public void CreateModules(Module[] moduleInfo)
+        public void CreateModules(IEnumerable<Module> moduleInfo)
         {
             foreach (var module in moduleInfo)
             {
-                var moduleHandle = _metadataBuilder.AddModule(
+                var moduleHandle = _metadata.Builder.AddModule(
                     0, // reserved in ECMA
-                    GetString(module.Name),
-                    GetGuid(module.ModuleVersionId),
-                    default(GuidHandle), // reserved in ECMA
-                    default(GuidHandle)); // reserved in ECMA
+                    _metadata.GetOrAddString(module.Name),
+                    _metadata.GetOrAddGuid(module.ModuleVersionId),
+                    default, // reserved in ECMA
+                    default); // reserved in ECMA
 
                 CreateCustomAttributes(moduleHandle, module.GetCustomAttributesData());
                 CreateFields(module.GetFields());

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using Lokad.ILPack.Metadata;
 
 namespace Lokad.ILPack
 {
@@ -102,7 +103,7 @@ namespace Lokad.ILPack
         internal static void FromSystemType(
             this ReturnTypeEncoder typeEncoder,
             Type type,
-            AssemblyGenerator generator)
+            IAssemblyMetadata metadata)
         {
             if (type == typeof(void))
             {
@@ -110,14 +111,12 @@ namespace Lokad.ILPack
             }
             else
             {
-                typeEncoder.Type().FromSystemType(type, generator);
+                typeEncoder.Type().FromSystemType(type, metadata);
             }
         }
 
-        internal static void FromSystemType(
-            this SignatureTypeEncoder typeEncoder,
-            Type type,
-            AssemblyGenerator generator)
+        internal static void FromSystemType(this SignatureTypeEncoder typeEncoder, Type type,
+            IAssemblyMetadata metadata)
         {
             if (type.IsPrimitive)
             {
@@ -143,7 +142,7 @@ namespace Lokad.ILPack
                 var rank = type.GetArrayRank();
 
                 typeEncoder.Array(
-                    x => x.FromSystemType(elementType, generator),
+                    x => x.FromSystemType(elementType, metadata),
                     x => x.Shape(
                         type.GetArrayRank(),
                         ImmutableArray.Create<int>(),
@@ -152,7 +151,7 @@ namespace Lokad.ILPack
             else if (type.IsGenericType)
             {
                 var genericTypeDef = type.GetGenericTypeDefinition();
-                var typeHandler = generator.GetOrCreateType(genericTypeDef);
+                var typeHandler = metadata.GetTypeHandle(genericTypeDef);
                 var genericArguments = type.GetGenericArguments();
 
                 var inst = typeEncoder.GenericInstantiation(typeHandler, genericArguments.Length, false);
@@ -164,13 +163,13 @@ namespace Lokad.ILPack
                     }
                     else
                     {
-                        inst.AddArgument().FromSystemType(ga, generator);
+                        inst.AddArgument().FromSystemType(ga, metadata);
                     }
                 }
             }
             else
             {
-                var typeHandler = generator.GetOrCreateType(type);
+                var typeHandler = metadata.GetTypeHandle(type);
                 typeEncoder.Type(typeHandler, type.IsValueType);
             }
         }

--- a/src/Extensions/IEnumerableExtensions.cs
+++ b/src/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+
+namespace System.Collections.Generic
+{
+    internal static class IEnumerableExtensions
+    {
+        // Reference: https://stackoverflow.com/a/24058279
+        public static IEnumerable<T> TopologicalSort<T>(this IEnumerable<T> nodes, Func<T, IEnumerable<T>> connected)
+        {
+            var elems = nodes.ToDictionary(node => node,
+                node => new HashSet<T>(connected(node)));
+            while (elems.Count > 0)
+            {
+                var elem = elems.FirstOrDefault(x => x.Value.Count == 0);
+                if (elem.Key == null)
+                {
+                    throw new ArgumentException("Cyclic connections are not allowed");
+                }
+
+                elems.Remove(elem.Key);
+                foreach (var kvp in elems)
+                {
+                    kvp.Value.Remove(elem.Key);
+                }
+
+                yield return elem.Key;
+            }
+        }
+    }
+}

--- a/src/IL/OpCodeExtensions.cs
+++ b/src/IL/OpCodeExtensions.cs
@@ -17,9 +17,9 @@ namespace Lokad.ILPack.IL
 
             var fields = GetOpCodeFields();
 
-            for (var i = 0; i < fields.Length; i++)
+            foreach (var t in fields)
             {
-                var opcode = (OpCode) fields[i].GetValue(null);
+                var opcode = (OpCode) t.GetValue(null);
                 if (opcode.OpCodeType == OpCodeType.Nternal)
                 {
                     continue;

--- a/src/Metadata/AssemblyMetadata.Assemblies.cs
+++ b/src/Metadata/AssemblyMetadata.Assemblies.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 
-namespace Lokad.ILPack
+namespace Lokad.ILPack.Metadata
 {
-    public partial class AssemblyGenerator
+    internal partial class AssemblyMetadata
     {
         private const string SystemRuntimeAssemblyName = "System.Runtime";
         private const string MscorlibAssemblyName = "mscorlib";
@@ -15,7 +15,7 @@ namespace Lokad.ILPack
 
         private AssemblyReferenceHandle GetCoreLibAssembly()
         {
-            return _assemblyReferenceHandles.First().Value;
+            return _assemblyRefHandles.First().Value;
         }
 
         private AssemblyReferenceHandle GetReferencedAssemblyForType(Type type)
@@ -34,9 +34,9 @@ namespace Lokad.ILPack
             }
 
             var uniqueName = asm.ToString();
-            if (_assemblyReferenceHandles.ContainsKey(uniqueName))
+            if (_assemblyRefHandles.ContainsKey(uniqueName))
             {
-                return _assemblyReferenceHandles[uniqueName];
+                return _assemblyRefHandles[uniqueName];
             }
 
             throw new Exception($"Referenced Assembly not found! ({asm.FullName})");
@@ -45,7 +45,7 @@ namespace Lokad.ILPack
         private void AddReferencedAssembly(string referenceName, AssemblyName assemblyName)
         {
             var uniqueName = assemblyName.ToString();
-            if (_assemblyReferenceHandles.ContainsKey(uniqueName))
+            if (_assemblyRefHandles.ContainsKey(uniqueName))
             {
                 return;
             }
@@ -58,15 +58,15 @@ namespace Lokad.ILPack
 
             var key = assemblyName.GetPublicKey();
             var hashOrToken = token ?? key;
-            var handle = _metadataBuilder.AddAssemblyReference(
-                GetString(referenceName),
+            var handle = Builder.AddAssemblyReference(
+                GetOrAddString(referenceName),
                 assemblyName.Version,
-                GetString(assemblyName.CultureName),
-                GetBlob(hashOrToken),
-                ConvertReferencedAssemblyNameFlags(assemblyName.Flags),
-                default(BlobHandle)); // Null is allowed
+                GetOrAddString(assemblyName.CultureName),
+                Builder.GetOrAddBlob(hashOrToken),
+                MetadataHelper.ConvertReferencedAssemblyNameFlags(assemblyName.Flags),
+                default); // Null is allowed
 
-            _assemblyReferenceHandles.Add(uniqueName, handle);
+            _assemblyRefHandles.Add(uniqueName, handle);
         }
 
         private static bool IsDotNetCore()

--- a/src/Metadata/AssemblyMetadata.Constructors.cs
+++ b/src/Metadata/AssemblyMetadata.Constructors.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public EntityHandle GetConstructorHandle(ConstructorInfo ctor)
+        {
+            if (TryGetConstructorDefinition(ctor, out var metadata))
+            {
+                return metadata.Handle;
+            }
+
+            if (_ctorRefHandles.TryGetValue(ctor, out var handle))
+            {
+                return handle;
+            }
+
+            throw new InvalidOperationException($"Constructor cannot be found: {ctor}");
+        }
+
+        internal BlobHandle GetConstructorSignature(ConstructorInfo constructorInfo)
+        {
+            var parameters = constructorInfo.GetParameters();
+            var countParameters = parameters.Length;
+
+            var blob = MetadataHelper.BuildSignature(x => x.MethodSignature(
+                    MetadataHelper.ConvertCallingConvention(constructorInfo.CallingConvention),
+                    isInstanceMethod: !constructorInfo.IsStatic)
+                .Parameters(
+                    countParameters,
+                    r => r.Void(),
+                    p =>
+                    {
+                        foreach (var par in parameters)
+                        {
+                            var parEncoder = p.AddParameter();
+                            parEncoder.Type().FromSystemType(par.ParameterType, this);
+                        }
+                    }));
+            return GetOrAddBlob(blob);
+        }
+
+        public MethodBaseDefinitionMetadata ReserveConstructorDefinition(ConstructorInfo ctor,
+            MethodDefinitionHandle handle)
+        {
+            var metadata = new MethodBaseDefinitionMetadata(ctor, handle);
+            _ctorDefHandles.Add(ctor, metadata);
+            return metadata;
+        }
+
+        public bool TryGetConstructorDefinition(ConstructorInfo ctor, out MethodBaseDefinitionMetadata metadata)
+        {
+            return _ctorDefHandles.TryGetValue(ctor, out metadata);
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.Fields.cs
+++ b/src/Metadata/AssemblyMetadata.Fields.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public EntityHandle GetFieldHandle(FieldInfo field)
+        {
+            if (TryGetFieldDefinition(field, out var metadata))
+            {
+                return metadata.Handle;
+            }
+
+            if (IsReferencedType(field.DeclaringType))
+            {
+                return ResolveFieldReference(field);
+            }
+
+            throw new InvalidOperationException($"Field cannot be found: {field}");
+        }
+
+        public BlobHandle GetFieldSignature(FieldInfo fieldInfo)
+        {
+            var type = fieldInfo.FieldType;
+            return GetOrAddBlob(MetadataHelper.BuildSignature(x =>
+                x.FieldSignature().FromSystemType(type, this)));
+        }
+
+        public FieldDefinitionMetadata ReserveFieldDefinition(FieldInfo field, FieldDefinitionHandle handle)
+        {
+            var metadata = new FieldDefinitionMetadata(field, handle);
+            _fieldDefHandles.Add(field, metadata);
+            return metadata;
+        }
+
+        private EntityHandle ResolveFieldReference(FieldInfo field)
+        {
+            if (!IsReferencedType(field.DeclaringType))
+            {
+                throw new ArgumentException("Field of a reference type is expected.", nameof(field));
+            }
+
+
+            if (_fieldRefHandles.TryGetValue(field, out var handle))
+            {
+                return handle;
+            }
+
+            var typeRef = ResolveTypeReference(field.DeclaringType);
+            var fieldRef = Builder.AddMemberReference(typeRef, GetOrAddString(field.Name), GetFieldSignature(field));
+            _fieldRefHandles.Add(field, fieldRef);
+            return fieldRef;
+        }
+
+        public bool TryGetFieldDefinition(FieldInfo field, out FieldDefinitionMetadata metadata)
+        {
+            return _fieldDefHandles.TryGetValue(field, out metadata);
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public EntityHandle GetMethodHandle(MethodInfo method)
+        {
+            if (TryGetMethodDefinition(method, out var metadata))
+            {
+                return metadata.Handle;
+            }
+
+            if (IsReferencedType(method.DeclaringType))
+            {
+                return ResolveMethodReference(method);
+            }
+
+            throw new InvalidOperationException($"Method cannot be found: {method}");
+        }
+
+        public BlobHandle GetMethodSignature(MethodInfo methodInfo)
+        {
+            var retType = methodInfo.ReturnType;
+            var parameters = methodInfo.GetParameters();
+            var countParameters = parameters.Length;
+
+            var blob = MetadataHelper.BuildSignature(x => x.MethodSignature(
+                    MetadataHelper.ConvertCallingConvention(methodInfo.CallingConvention),
+                    isInstanceMethod: !methodInfo.IsStatic)
+                .Parameters(
+                    countParameters,
+                    r => r.FromSystemType(retType, this),
+                    p =>
+                    {
+                        foreach (var par in parameters)
+                        {
+                            var parEncoder = p.AddParameter();
+                            parEncoder.Type().FromSystemType(par.ParameterType, this);
+                        }
+                    }));
+            return GetOrAddBlob(blob);
+        }
+
+        private EntityHandle ResolveMethodReference(MethodInfo method)
+        {
+            if (!IsReferencedType(method.DeclaringType))
+            {
+                throw new ArgumentException("Method of a reference type is expected.", nameof(method));
+            }
+
+            if (_methodRefHandles.TryGetValue(method, out var handle))
+            {
+                return handle;
+            }
+
+            var typeRef = ResolveTypeReference(method.DeclaringType);
+            var methodRef = Builder.AddMemberReference(typeRef, GetOrAddString(method.Name),
+                GetMethodSignature(method));
+            _methodRefHandles.Add(method, methodRef);
+            return methodRef;
+        }
+
+        public bool TryGetMethodDefinition(MethodInfo methodInfo, out MethodBaseDefinitionMetadata metadata)
+        {
+            return _methodDefHandles.TryGetValue(methodInfo, out metadata);
+        }
+
+        public MethodBaseDefinitionMetadata ReserveMethodDefinition(MethodInfo method, MethodDefinitionHandle handle)
+        {
+            var metadata = new MethodBaseDefinitionMetadata(method, handle);
+            _methodDefHandles.Add(method, metadata);
+            return metadata;
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.Parameters.cs
+++ b/src/Metadata/AssemblyMetadata.Parameters.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public bool TryGetParameterHandle(ParameterInfo parameter, out ParameterHandle handle)
+        {
+            return _parameterHandles.TryGetValue(parameter, out handle);
+        }
+
+        public void AddParameterHandle(ParameterInfo parameter, ParameterHandle handle)
+        {
+            _parameterHandles.Add(parameter, handle);
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.Properties.cs
+++ b/src/Metadata/AssemblyMetadata.Properties.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public PropertyDefinitionMetadata ReservePropertyDefinition(PropertyInfo property,
+            PropertyDefinitionHandle propertyHandle, MethodDefinitionHandle getMethodHandle,
+            MethodDefinitionHandle setMethodHandle)
+        {
+            var metadata = new PropertyDefinitionMetadata(property, propertyHandle, getMethodHandle, setMethodHandle);
+            _propertyHandles.Add(property, metadata);
+            return metadata;
+        }
+
+        public bool TryGetPropertyMetadata(PropertyInfo property, out PropertyDefinitionMetadata metadata)
+        {
+            return _propertyHandles.TryGetValue(property, out metadata);
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata
+    {
+        public EntityHandle GetTypeHandle(Type type)
+        {
+            if (TryGetTypeDefinition(type, out var metadata))
+            {
+                return metadata.Handle;
+            }
+
+            if (IsReferencedType(type))
+            {
+                return ResolveTypeReference(type);
+            }
+
+            throw new InvalidOperationException($"Type cannot be found: {type}");
+        }
+
+        public bool IsReferencedType(Type type)
+        {
+            // todo, also maybe in Module, ModuleRef, AssemblyRef and TypeRef
+            // ECMA-335 page 273-274
+            return type.Assembly != SourceAssembly;
+        }
+
+        private EntityHandle GetResolutionScopeForType(Type type)
+        {
+            return GetReferencedAssemblyForType(type);
+        }
+
+        private EntityHandle ResolveTypeReference(Type type)
+        {
+            if (!IsReferencedType(type))
+            {
+                throw new ArgumentException("Reference type is expected.", nameof(type));
+            }
+
+            if (_typeRefHandles.TryGetValue(type.GUID, out var typeRef))
+            {
+                return typeRef;
+            }
+
+            var scope = GetResolutionScopeForType(type);
+            var typeHandle = Builder.AddTypeReference(
+                scope,
+                GetOrAddString(type.Namespace),
+                GetOrAddString(type.Name));
+
+            _typeRefHandles.Add(type.GUID, typeHandle);
+
+            // Create all public constructor references
+            foreach (var ctor in type.GetConstructors())
+            {
+                var signature = GetConstructorSignature(ctor);
+                var ctorRef = Builder.AddMemberReference(typeHandle, GetOrAddString(ctor.Name), signature);
+                _ctorRefHandles.Add(ctor, ctorRef);
+            }
+
+            return typeHandle;
+        }
+
+        public TypeDefinitionMetadata ReserveTypeDefinition(Type type, TypeDefinitionHandle handle, int fieldIndex,
+            int propertyIndex, int methodIndex)
+        {
+            var metadata = new TypeDefinitionMetadata(type, handle, fieldIndex, propertyIndex, methodIndex);
+            _typeDefHandles.Add(type.GUID, metadata);
+            return metadata;
+        }
+
+        public bool TryGetTypeDefinition(Type type, out TypeDefinitionMetadata metadata)
+        {
+            return _typeDefHandles.TryGetValue(type.GUID, out metadata);
+        }
+    }
+}

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal partial class AssemblyMetadata : IAssemblyMetadata
+    {
+        private readonly Dictionary<string, AssemblyReferenceHandle> _assemblyRefHandles;
+        private readonly Dictionary<ConstructorInfo, MethodBaseDefinitionMetadata> _ctorDefHandles;
+        private readonly Dictionary<ConstructorInfo, MemberReferenceHandle> _ctorRefHandles;
+        private readonly Dictionary<FieldInfo, FieldDefinitionMetadata> _fieldDefHandles;
+        private readonly Dictionary<FieldInfo, MemberReferenceHandle> _fieldRefHandles;
+        private readonly Dictionary<MethodInfo, MethodBaseDefinitionMetadata> _methodDefHandles;
+        private readonly Dictionary<MethodInfo, MemberReferenceHandle> _methodRefHandles;
+        private readonly Dictionary<ParameterInfo, ParameterHandle> _parameterHandles;
+        private readonly Dictionary<PropertyInfo, PropertyDefinitionMetadata> _propertyHandles;
+        private readonly Dictionary<Guid, TypeDefinitionMetadata> _typeDefHandles;
+        private readonly Dictionary<Guid, TypeReferenceHandle> _typeRefHandles;
+
+        public AssemblyMetadata(Assembly sourceAssembly)
+        {
+            SourceAssembly = sourceAssembly;
+            Builder = new MetadataBuilder();
+            ILBuilder = new BlobBuilder();
+
+            _assemblyRefHandles = new Dictionary<string, AssemblyReferenceHandle>();
+            _ctorDefHandles = new Dictionary<ConstructorInfo, MethodBaseDefinitionMetadata>();
+            _ctorRefHandles = new Dictionary<ConstructorInfo, MemberReferenceHandle>();
+            _fieldDefHandles = new Dictionary<FieldInfo, FieldDefinitionMetadata>();
+            _fieldRefHandles = new Dictionary<FieldInfo, MemberReferenceHandle>();
+            _methodDefHandles = new Dictionary<MethodInfo, MethodBaseDefinitionMetadata>();
+            _methodRefHandles = new Dictionary<MethodInfo, MemberReferenceHandle>();
+            _parameterHandles = new Dictionary<ParameterInfo, ParameterHandle>();
+            _propertyHandles = new Dictionary<PropertyInfo, PropertyDefinitionMetadata>();
+            _typeDefHandles = new Dictionary<Guid, TypeDefinitionMetadata>();
+            _typeRefHandles = new Dictionary<Guid, TypeReferenceHandle>();
+
+            CreateReferencedAssemblies(SourceAssembly.GetReferencedAssemblies());
+        }
+
+        public Assembly SourceAssembly { get; }
+        public MetadataBuilder Builder { get; }
+        public BlobBuilder ILBuilder { get; }
+
+        public UserStringHandle GetOrAddUserString(string value)
+        {
+            return Builder.GetOrAddUserString(value);
+        }
+
+        public BlobHandle GetOrAddBlob(byte[] value)
+        {
+            return Builder.GetOrAddBlob(value);
+        }
+
+        public BlobHandle GetOrAddBlob(BlobBuilder value)
+        {
+            return Builder.GetOrAddBlob(value);
+        }
+
+        public GuidHandle GetOrAddGuid(Guid value)
+        {
+            return Builder.GetOrAddGuid(value);
+        }
+
+        public StringHandle GetOrAddString(string value)
+        {
+            return Builder.GetOrAddString(value);
+        }
+    }
+}

--- a/src/Metadata/IAssemblyMetadata.cs
+++ b/src/Metadata/IAssemblyMetadata.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    public interface IAssemblyMetadata
+    {
+        BlobBuilder ILBuilder { get; }
+
+        UserStringHandle GetOrAddUserString(string value);
+        EntityHandle GetTypeHandle(Type type);
+        EntityHandle GetFieldHandle(FieldInfo field);
+        EntityHandle GetConstructorHandle(ConstructorInfo ctor);
+        EntityHandle GetMethodHandle(MethodInfo method);
+    }
+}

--- a/src/Metadata/Metadata.cs
+++ b/src/Metadata/Metadata.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal abstract class DefinitionMetadata<TEntity, THandle>
+    {
+        protected DefinitionMetadata(TEntity entity, THandle handle)
+        {
+            IsEmitted = false;
+            Entity = entity;
+            Handle = handle;
+        }
+
+        public bool IsEmitted { get; private set; }
+        public TEntity Entity { get; }
+        public THandle Handle { get; }
+
+        public void MarkAsEmitted()
+        {
+            IsEmitted = true;
+        }
+    }
+
+    internal class FieldDefinitionMetadata : DefinitionMetadata<FieldInfo, FieldDefinitionHandle>
+    {
+        public FieldDefinitionMetadata(FieldInfo method, FieldDefinitionHandle handle) : base(method, handle)
+        {
+        }
+    }
+
+    internal class PropertyDefinitionMetadata : DefinitionMetadata<PropertyInfo, PropertyDefinitionHandle>
+    {
+        public PropertyDefinitionMetadata(PropertyInfo property, PropertyDefinitionHandle propertyHandle,
+            MethodDefinitionHandle getMethodHandle, MethodDefinitionHandle setMethodHandle) : base(property,
+            propertyHandle)
+        {
+            GetMethodHandle = getMethodHandle;
+            SetMethodHandle = setMethodHandle;
+        }
+
+        public MethodDefinitionHandle GetMethodHandle { get; }
+        public MethodDefinitionHandle SetMethodHandle { get; }
+    }
+
+    internal class MethodBaseDefinitionMetadata : DefinitionMetadata<MethodBase, MethodDefinitionHandle>
+    {
+        public MethodBaseDefinitionMetadata(MethodBase method, MethodDefinitionHandle handle) : base(method, handle)
+        {
+        }
+    }
+
+    internal class TypeDefinitionMetadataOffset
+    {
+        public int FieldIndex { get; set; }
+        public int PropertyIndex { get; set; }
+        public int MethodIndex { get; set; }
+    }
+
+    internal class TypeDefinitionMetadata : DefinitionMetadata<Type, EntityHandle>
+    {
+        public TypeDefinitionMetadata(Type type, EntityHandle handle, int fieldIndex, int propertyIndex,
+            int methodIndex) : base(type, handle)
+        {
+            FieldIndex = fieldIndex;
+            PropertyIndex = propertyIndex;
+            MethodIndex = methodIndex;
+        }
+
+        public int FieldIndex { get; }
+        public int PropertyIndex { get; }
+        public int MethodIndex { get; }
+    }
+}

--- a/src/Metadata/MetadataHelper.cs
+++ b/src/Metadata/MetadataHelper.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Lokad.ILPack.Metadata
+{
+    internal static class MetadataHelper
+    {
+        public static AssemblyFlags ConvertAssemblyNameFlags(AssemblyNameFlags flags)
+        {
+            var result = (AssemblyFlags) 0;
+
+            if (flags.HasFlag(AssemblyNameFlags.PublicKey))
+            {
+                result |= AssemblyFlags.PublicKey;
+            }
+
+            if (flags.HasFlag(AssemblyNameFlags.Retargetable))
+            {
+                result |= AssemblyFlags.Retargetable;
+            }
+
+            // No, it's not a typo. Microsoft decided to put "exact opposite of the meaning" for this flag.
+            if (flags.HasFlag(AssemblyNameFlags.EnableJITcompileOptimizer))
+            {
+                result |= AssemblyFlags.DisableJitCompileOptimizer;
+            }
+
+            if (flags.HasFlag(AssemblyNameFlags.EnableJITcompileTracking))
+            {
+                result |= AssemblyFlags.EnableJitCompileTracking;
+            }
+
+            return result;
+        }
+
+        public static AssemblyFlags ConvertReferencedAssemblyNameFlags(AssemblyNameFlags flags)
+        {
+            var result = ConvertAssemblyNameFlags(flags);
+
+            // TODO: [osman] Referenced runtime assemblies don't have PublicKey flag.
+            // How should we handle an assembly which doesn't have a strong name?
+            result &= ~AssemblyFlags.PublicKey;
+
+            return result;
+        }
+
+        public static SignatureCallingConvention ConvertCallingConvention(CallingConventions callingConvention)
+        {
+            // TODO: incorrect / draft implementation
+            // See https://stackoverflow.com/questions/54632913/how-to-convert-callingconventions-into-signaturecallingconvention
+
+            //if (callingConvention.HasFlag(CallingConventions.Any))
+            //    result |= SignatureCallingConvention.StdCall | SignatureCallingConvention.VarArgs;
+
+            //if (callingConvention.HasFlag(CallingConventions.ExplicitThis))
+            //    result = 0x40;
+
+            //else if (callingConvention.HasFlag(CallingConventions.HasThis))
+            //    result = 0x20;
+
+            SignatureCallingConvention result = 0;
+
+            //if(callingConvention.HasFlag(CallingConventions.HasThis))
+            //    result |= SignatureCallingConvention.ThisCall;
+
+            //if (callingConvention.HasFlag(CallingConventions.Standard))
+            //    result |= SignatureCallingConvention.StdCall;
+
+            if (callingConvention.HasFlag(CallingConventions.VarArgs))
+            {
+                result |= SignatureCallingConvention.VarArgs;
+            }
+
+            return result;
+
+            /*
+            var result = SignatureCallingConvention.Default;
+            
+            if (callingConvention.HasFlag(CallingConventions.Any))
+                result |= SignatureCallingConvention.StdCall | SignatureCallingConvention.VarArgs;
+
+            if (callingConvention.HasFlag(CallingConventions.ExplicitThis))
+                throw new Exception("Unknown Calling Convention (ExplicitThis)");
+
+            if (callingConvention.HasFlag(CallingConventions.HasThis))
+                result |= SignatureCallingConvention.ThisCall;
+
+            if (callingConvention.HasFlag(CallingConventions.Standard))
+                result |= SignatureCallingConvention.StdCall;
+
+            if (callingConvention.HasFlag(CallingConventions.VarArgs))
+                result |= SignatureCallingConvention.VarArgs;
+
+            return result;
+            */
+        }
+
+        public static BlobBuilder BuildSignature(Action<BlobEncoder> action)
+        {
+            var builder = new BlobBuilder();
+            action(new BlobEncoder(builder));
+            return builder;
+        }
+
+        public static BlobBuilder BuildSignature(BlobBuilder builder, Action<BlobEncoder> action)
+        {
+            action(new BlobEncoder(builder));
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
This commit fixes cyclic dependency by 2-pass algorithm. First pass sorts types by dependency and reserves metadata tokens for each entity definitions (fields, properties, constructors, methods and types). Second pass emits actual metadata. Referenced entities are progressively resolved since they don't need such dependency resolution. There are some measures to ensure reserved and actual emitted metadata tokens are same.

Also, this commit fixes user string handling. `OperandType.InlineString` requires user string metadata token which is allocated by `GetOrAddUserString` (`#US` in .NET metadata). Old implementation use strings in `#Strings` heap which is allocated by `GetOrAddString`.

To cover all changes, basic type dependency (`TestBasicInheritance`), external method referencing (`TestMethodReferencingSerialization`) and self-referencing (`TestSelfReferencingSerialization`) unit tests are provided.

Also, the source code is cleaned-up by removing unused references, tidying code blocks, replacing some code blocks with common patterns etc.

Resolves: #22, #30