### PR TITLE
Fix null strings

### DIFF
--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -47,17 +47,17 @@ namespace Lokad.ILPack.Metadata
 
         public UserStringHandle GetOrAddUserString(string value)
         {
-            return Builder.GetOrAddUserString(value);
+            return value != null ? Builder.GetOrAddUserString(value) : default;
         }
 
         public BlobHandle GetOrAddBlob(byte[] value)
         {
-            return Builder.GetOrAddBlob(value);
+            return value != null ? Builder.GetOrAddBlob(value) : default;
         }
 
         public BlobHandle GetOrAddBlob(BlobBuilder value)
         {
-            return Builder.GetOrAddBlob(value);
+            return value != null ? Builder.GetOrAddBlob(value) : default;
         }
 
         public GuidHandle GetOrAddGuid(Guid value)
@@ -67,7 +67,7 @@ namespace Lokad.ILPack.Metadata
 
         public StringHandle GetOrAddString(string value)
         {
-            return Builder.GetOrAddString(value);
+            return value != null ? Builder.GetOrAddString(value) : default;
         }
     }
 }


### PR DESCRIPTION
This commit fixes null strings to support types with no namespace. Also, user strings and blobs are supported with null references now (provides a null metadata handle instead of throwing an exception). A unit test is provided with a anonymous type and a type with no namespace to support this commit.

See: #9, #28, #33