### PR TITLE
Fix inline constructor reference resolving

### DIFF
--- a/src/IL/MethodBodyReader.cs
+++ b/src/IL/MethodBodyReader.cs
@@ -128,6 +128,7 @@ namespace Lokad.ILPack.IL
                 case OperandType.InlineTok:
                     instruction.Operand = _module.ResolveMember(_il.ReadInt32(), _typeArguments, _methodArguments);
                     break;
+
                 case OperandType.InlineType:
                     instruction.Operand = _module.ResolveType(_il.ReadInt32(), _typeArguments, _methodArguments);
                     break;

--- a/src/Metadata/AssemblyMetadata.Constructors.cs
+++ b/src/Metadata/AssemblyMetadata.Constructors.cs
@@ -13,9 +13,15 @@ namespace Lokad.ILPack.Metadata
                 return metadata.Handle;
             }
 
-            if (_ctorRefHandles.TryGetValue(ctor, out var handle))
+            if (IsReferencedType(ctor.DeclaringType))
             {
-                return handle;
+                // Make sure type reference and all public constructors are resolved
+                ResolveTypeReference(ctor.DeclaringType);
+
+                if (_ctorRefHandles.TryGetValue(ctor, out var handle))
+                {
+                    return handle;
+                }
             }
 
             throw new InvalidOperationException($"Constructor cannot be found: {ctor}");


### PR DESCRIPTION
In old implementation, if a type reference is found, all of its public constructor references are resolved. But, if a type reference is not referenced as a type at anywhere and one of its constructor is invoked in a method body, old implementation mistakenly assumed constructor reference should be available. This commit fixes this problem. Also, a new unit test is added to demonstrate the problem.

See: #33