### PR TITLE
Fix property serialization

### DIFF
--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -102,25 +102,11 @@ namespace Lokad.ILPack
 
             foreach (var property in type.GetProperties(AllProperties))
             {
+                // We don't need to handle backing field. Because, it's handled as a regular field.
+                // Also, we don't need to handle getter or setter. Because, they are handled as regular methods.
                 var propertyHandle = MetadataTokens.PropertyDefinitionHandle(propertyRowCount + 1);
+                _metadata.ReservePropertyDefinition(property, propertyHandle);
                 ++propertyRowCount;
-
-                MethodDefinitionHandle getMethodHandle = default;
-                MethodDefinitionHandle setMethodHandle = default;
-
-                if (property.GetMethod != null)
-                {
-                    getMethodHandle = MetadataTokens.MethodDefinitionHandle(methodRowCount + 1);
-                    ++methodRowCount;
-                }
-
-                if (property.SetMethod != null)
-                {
-                    setMethodHandle = MetadataTokens.MethodDefinitionHandle(methodRowCount + 1);
-                    ++methodRowCount;
-                }
-
-                _metadata.ReservePropertyDefinition(property, propertyHandle, getMethodHandle, setMethodHandle);
             }
 
             foreach (var ctor in type.GetConstructors(AllMethods))

--- a/src/Metadata/AssemblyMetadata.Properties.cs
+++ b/src/Metadata/AssemblyMetadata.Properties.cs
@@ -6,10 +6,9 @@ namespace Lokad.ILPack.Metadata
     internal partial class AssemblyMetadata
     {
         public PropertyDefinitionMetadata ReservePropertyDefinition(PropertyInfo property,
-            PropertyDefinitionHandle propertyHandle, MethodDefinitionHandle getMethodHandle,
-            MethodDefinitionHandle setMethodHandle)
+            PropertyDefinitionHandle propertyHandle)
         {
-            var metadata = new PropertyDefinitionMetadata(property, propertyHandle, getMethodHandle, setMethodHandle);
+            var metadata = new PropertyDefinitionMetadata(property, propertyHandle);
             _propertyHandles.Add(property, metadata);
             return metadata;
         }

--- a/src/Metadata/Metadata.cs
+++ b/src/Metadata/Metadata.cs
@@ -32,16 +32,10 @@ namespace Lokad.ILPack.Metadata
 
     internal class PropertyDefinitionMetadata : DefinitionMetadata<PropertyInfo, PropertyDefinitionHandle>
     {
-        public PropertyDefinitionMetadata(PropertyInfo property, PropertyDefinitionHandle propertyHandle,
-            MethodDefinitionHandle getMethodHandle, MethodDefinitionHandle setMethodHandle) : base(property,
-            propertyHandle)
+        public PropertyDefinitionMetadata(PropertyInfo property, PropertyDefinitionHandle propertyHandle) : base(
+            property, propertyHandle)
         {
-            GetMethodHandle = getMethodHandle;
-            SetMethodHandle = setMethodHandle;
         }
-
-        public MethodDefinitionHandle GetMethodHandle { get; }
-        public MethodDefinitionHandle SetMethodHandle { get; }
     }
 
     internal class MethodBaseDefinitionMetadata : DefinitionMetadata<MethodBase, MethodDefinitionHandle>


### PR DESCRIPTION
Property serialization was wrong due to double metadata token reservation for getter and setter methods. This commit fixes this problem and adds a new unit test for property serialization.

See: #9