### PR TITLE
Fixed test case incorrectly generating property setters

### DIFF
--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -73,8 +73,8 @@ namespace Lokad.ILPack.Tests
             {
                 // Define set method
                 var propertySetterName = $"set_${propertyName}";
-                var propertySetter = typeBuilder.DefineMethod(propertySetterName, MethodAttributes.Public, propertyType,
-                    Type.EmptyTypes);
+                var propertySetter = typeBuilder.DefineMethod(propertySetterName, MethodAttributes.Public, null,
+                    new Type[] { propertyType });
 
                 var il = propertySetter.GetILGenerator();
                 il.Emit(OpCodes.Ldarg_0);


### PR DESCRIPTION
Property setters are supposed to be void return with implicit value parameter