### PR TITLE
Fix for runtime crash for any method with local variable

### DIFF
--- a/src/IL/MethodBodyStreamWriter.cs
+++ b/src/IL/MethodBodyStreamWriter.cs
@@ -24,12 +24,19 @@ namespace Lokad.ILPack.IL
                 return _metadata.ILBuilder.Count;
             }
 
+            var localVariables = body.LocalVariables.ToArray();
+			var localEncoder = new BlobEncoder(new BlobBuilder()).LocalVariableSignature(localVariables.Length);
+            foreach (var l in localVariables)
+            {
+                localEncoder.AddVariable().Type().FromSystemType(l.LocalType, _metadata); 
+            }
+
             var instructions = methodBase.GetInstructions();
             var maxStack = body.MaxStackSize;
             var codeSize = body.GetILAsByteArray().Length;
             var exceptionRegionCount = body.ExceptionHandlingClauses.Count;
             var attributes = body.InitLocals ? MethodBodyAttributes.InitLocals : MethodBodyAttributes.None;
-            var localVariablesSignature = default(StandaloneSignatureHandle);
+            var localVariablesSignature = _metadata.AddStandAloneSignature(localEncoder.Builder);
             var hasDynamicStackAllocation = instructions.Any(x => x.OpCode == OpCodes.Localloc);
 
             var offset = SerializeHeader(codeSize, maxStack, exceptionRegionCount, attributes, localVariablesSignature,

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -65,6 +65,12 @@ namespace Lokad.ILPack.Metadata
             return Builder.GetOrAddGuid(value);
         }
 
+        public StandaloneSignatureHandle AddStandAloneSignature(BlobBuilder blobBuilder)
+        {
+            return Builder.AddStandaloneSignature(GetOrAddBlob(blobBuilder));
+        }
+        
+
         public StringHandle GetOrAddString(string value)
         {
             return value != null ? Builder.GetOrAddString(value) : default;

--- a/src/Metadata/IAssemblyMetadata.cs
+++ b/src/Metadata/IAssemblyMetadata.cs
@@ -13,5 +13,6 @@ namespace Lokad.ILPack.Metadata
         EntityHandle GetFieldHandle(FieldInfo field);
         EntityHandle GetConstructorHandle(ConstructorInfo ctor);
         EntityHandle GetMethodHandle(MethodInfo method);
+        StandaloneSignatureHandle AddStandAloneSignature(BlobBuilder blobBuilder);
     }
 }


### PR DESCRIPTION
This is a fix to generate the (previously missing) local variable signatures that caused any method with local variables to crash with a runtime exception.

Note this probably only works for system types.  Not tested with externally referenced types.