### PR TITLE
Fix for references to instantiated generic types

### DIFF
--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Lokad.ILPack.Metadata
 {
@@ -7,6 +8,13 @@ namespace Lokad.ILPack.Metadata
     {
         public EntityHandle GetTypeHandle(Type type)
         {
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                var typeSpecEncoder = new BlobEncoder(new BlobBuilder()).TypeSpecificationSignature();
+                typeSpecEncoder.FromSystemType(type, this);
+                return Builder.AddTypeSpecification(GetOrAddBlob(typeSpecEncoder.Builder));
+            }
+
             if (TryGetTypeDefinition(type, out var metadata))
             {
                 return metadata.Handle;


### PR DESCRIPTION
For for type references to instantiated generic types.

eg: this C# code:

```
event Action<int> MyEvent;
```

was producing metadata as:

```
event Action<> MyEvent
```


