### PR TITLE
Update to the RewriteTests test cases to actually invoke the newly rewritten assembly

### DIFF
--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -135,7 +135,7 @@ namespace Lokad.ILPack
 
             var typeHandle = _metadata.Builder.AddTypeDefinition(
                 type.Attributes,
-                _metadata.GetOrAddString(type.Namespace),
+                _metadata.GetOrAddString(ApplyNameChange(type.Namespace)),
                 _metadata.GetOrAddString(type.Name),
                 baseTypeHandle,
                 MetadataTokens.FieldDefinitionHandle(offset.FieldIndex + 1),

--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -19,6 +19,27 @@ namespace Lokad.ILPack
             _debugDirectoryBuilder = new DebugDirectoryBuilder();
         }
 
+        // Called by the unit tests to rename the assembly and the namespaces
+        // in the rewritten assembly.  This allows the unit tests to load
+        // both RewrittenOriginal.dll and RewrittenClone.dll.
+        internal void RenameForTesting(string oldName, string newName)
+        {
+            _oldName = oldName;
+            _newName = newName;
+        }
+
+        string _oldName;
+        string _newName;
+
+        // Apply name changes to assembly and namespace names
+        internal string ApplyNameChange(string str)
+        {
+            if (_oldName == null)
+                return str;
+            else
+                return str.Replace(_oldName, _newName);
+        }
+
         public byte[] GenerateAssemblyBytes(Assembly assembly)
         {
             Initialize(assembly);
@@ -33,7 +54,7 @@ namespace Lokad.ILPack
 
             var assemblyPublicKey = name.GetPublicKey();
             var assemblyHandle = _metadata.Builder.AddAssembly(
-                _metadata.GetOrAddString(name.Name),
+                _metadata.GetOrAddString(ApplyNameChange(name.Name)),
                 name.Version,
                 _metadata.GetOrAddString(name.CultureName),
                 assemblyPublicKey.Length > 0 ? _metadata.GetOrAddBlob(name.GetPublicKey()) : default,

--- a/test/Lokad.ILPack.Tests/.gitignore
+++ b/test/Lokad.ILPack.Tests/.gitignore
@@ -1,0 +1,2 @@
+il.*.txt
+md.*.txt

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/test/Lokad.ILPack.Tests/RewriteTest.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.cs
@@ -43,8 +43,8 @@ namespace Lokad.ILPack.Tests
         static RewriteTest()
         {
             // Get the original assembly
-            var original = typeof(RewriteOriginal.MyClass).Assembly;
-            var originalAssembly = original.Location;
+            _asmOriginal = typeof(RewriteOriginal.MyClass).Assembly;
+            var originalAssembly = _asmOriginal.Location;
 
             // Generate the cloned assembly
             // NB: putting it in the "cloned" sub directory prevents an
@@ -57,7 +57,7 @@ namespace Lokad.ILPack.Tests
             // Rewrite it (renaming the assembly and namespaces in the process)
             var generator = new AssemblyGenerator();
             generator.RenameForTesting("RewriteOriginal", "RewriteClone");
-            generator.GenerateAssembly(original, clonedAssembly);
+            generator.GenerateAssembly(_asmOriginal, clonedAssembly);
 
             _namespaceName = "RewriteClone";
             _assembly = clonedAssembly;
@@ -66,10 +66,14 @@ namespace Lokad.ILPack.Tests
             // (handy to check if test case is wrong)
             //_namespaceName = "RewriteOriginal";
             //_assembly = originalAssembly;
+
+            _asmCloned = Assembly.LoadFrom(_assembly);
         }
 
         static string _namespaceName;
         static string _assembly;
+        static Assembly _asmOriginal;
+        static Assembly _asmCloned;
 
         async Task<object> Invoke(string setup, string resultExpression)
         {
@@ -150,6 +154,25 @@ namespace Lokad.ILPack.Tests
                     x.InvokeIntParamEvent(77)",
                    
                 "cbVal"));
+        }
+
+        [Fact]
+        public void AssemblyTargetFramework()
+        {
+            var targetFrameworkOriginal = _asmOriginal.GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>();
+            var targetFrameworkClone = _asmCloned.GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>();
+
+            Assert.Equal(targetFrameworkOriginal.FrameworkDisplayName, targetFrameworkClone.FrameworkDisplayName);
+            Assert.Equal(targetFrameworkOriginal.FrameworkName, targetFrameworkClone.FrameworkName);
+        }
+
+        [Fact]
+        public void AssemblyName()
+        {
+            var titleOriginal = _asmOriginal.GetCustomAttribute<System.Reflection.AssemblyTitleAttribute>();
+            var titleClone = _asmCloned.GetCustomAttribute<System.Reflection.AssemblyTitleAttribute>();
+
+            Assert.Equal(titleOriginal.Title, titleClone.Title);
         }
 
     }

--- a/test/Lokad.ILPack.Tests/dump.bat
+++ b/test/Lokad.ILPack.Tests/dump.bat
@@ -1,0 +1,4 @@
+ildasm bin\Debug\netcoreapp2.1\RewriteOriginal.dll > il.original.txt
+ildasm bin\Debug\netcoreapp2.1\cloned\RewriteClone.dll > il.clone.txt
+mddumper bin\Debug\netcoreapp2.1\RewriteOriginal.dll > md.original.txt
+mddumper bin\Debug\netcoreapp2.1\cloned\RewriteClone.dll > md.clone.txt

--- a/test/Lokad.ILPack.Tests/dump.bat
+++ b/test/Lokad.ILPack.Tests/dump.bat
@@ -1,4 +1,4 @@
-ildasm bin\Debug\netcoreapp2.1\RewriteOriginal.dll > il.original.txt
-ildasm bin\Debug\netcoreapp2.1\cloned\RewriteClone.dll > il.clone.txt
+ildasm /bytes bin\Debug\netcoreapp2.1\RewriteOriginal.dll > il.original.txt
+ildasm /bytes bin\Debug\netcoreapp2.1\cloned\RewriteClone.dll > il.clone.txt
 mddumper bin\Debug\netcoreapp2.1\RewriteOriginal.dll > md.original.txt
 mddumper bin\Debug\netcoreapp2.1\cloned\RewriteClone.dll > md.clone.txt

--- a/test/RewriteOriginal/MyClass.cs
+++ b/test/RewriteOriginal/MyClass.cs
@@ -14,11 +14,11 @@ namespace RewriteOriginal
         public int ReadOnlyProperty
         {
             get;
-        }
+        } = 23;
 
         public int WriteOnlyProperty
         {
-            get;
+            set { }
         }
 
         public int ReadWriteProperty
@@ -33,7 +33,7 @@ namespace RewriteOriginal
 
         public int IntMethod()
         {
-            return 0;
+            return 33;
         }
 
         public int IntMethodWithParameters(int a, int b)
@@ -55,5 +55,15 @@ namespace RewriteOriginal
 
         public event Action NoParamEvent;
         public event Action<int> IntParamEvent;
+
+        public void InvokeNoParamEvent()
+        {
+            NoParamEvent?.Invoke();
+        }
+
+        public void InvokeIntParamEvent(int withValue)
+        {
+            IntParamEvent?.Invoke(withValue);
+        }
     }
 }


### PR DESCRIPTION
Note: this approach requires one small (but worthwhile) change to ILPack to allow it to rename the assembly and namespace meta data that it generates.  This allows the test runner to load both the original and the cloned assembly without needing AppDomain support (which netcore doesn't have).

Overall this is a much cleaner approach than previous pull request #51 which I've retracted.  Also I've removed the original test cases from RewriteTests which weren't really effective in detecting problems and this new approach should cover everything they did anyway.

The notes below are copied from comments included in the RewriteTests.cs test case file.

Finally, note that some of the test cases included here are failing, but they're separate issues to this pull request.

---

These test cases work by taking the RewriteOriginal project, passing it
through ILPack to generate a new assembly and then checking that the
newly generated assembly is correct by actually loading it and invoking
methods and properties on it.

It works as follows:

1. `RewriteOriginal.dll` is loaded through a project reference and found
   with a simple typeof(MyClass)
   
2. ILPack is used to to rewrite a new assembly `RewriteClone.dll`

3. To allow the second DLL to be loaded into the same process (we don't
   have AppDomains under net core), we use ILPack's RenameForTesting method
   to change the names of the assembly and the contained namespace(s)
   
4. Use CSharpScript to load the newly cloned assembly and poke it in 
   various ways to make sure it still works.
   
Also, in the Lokad.ILPack.Tests project folder there's a dump.bat script
which on Windows will run ildasm and mddumper on both the original and the
cloned assemblies.  Handy for comparison when diagnosing issues. (ildasm
and mddumper both need to be on your path)

