### PR TITLE
Rewrote support for custom attributes (scalars only)

### DIFF
--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -40,6 +40,8 @@ namespace Lokad.ILPack
                 ConvertGeneratedAssemblyNameFlags(name),
                 ConvertAssemblyHashAlgorithm(name.HashAlgorithm));
 
+            CreateCustomAttributes(assemblyHandle, assembly.GetCustomAttributesData());
+
             // Add "<Module>" type definition *before* any type definition.
             //
             // TODO: [osman] methodList argument should be as following:


### PR DESCRIPTION
Attribute support was previously comment out.  This is a rewrite that uses the System.Reflection.Metadata.Ecma335 encoders for customer attribute data (rather than trying to manually build those blobs).  Also, added call to copy custom attributes for the assembly itself.

Seems to work well for scalar types.  Array data not supported (should throw exception)

Testing with RewriteOriginal shows compiler generated attributes, assembly info attributes getting copied across by idasm.  Unit tests for a couple of assembly attributes are included in separate PR #52 