### PR TITLE
Fixes for some generics related issues, [out] and [ref] parameters

### DIFF
--- a/src/AssemblyGenerator.Parameters.cs
+++ b/src/AssemblyGenerator.Parameters.cs
@@ -40,7 +40,7 @@ namespace Lokad.ILPack
                 System.Diagnostics.Debug.Assert(parameterDef == MetadataTokens.ParameterHandle(_nextParameterRowId));
 
                 _metadata.AddParameterHandle(parameter, parameterDef);
-                //CreateCustomAttributes(parameterDef, parameter.GetCustomAttributesData());
+                CreateCustomAttributes(parameterDef, parameter.GetCustomAttributesData());
 
                 _nextParameterRowId++;
             }

--- a/src/AssemblyGenerator.Parameters.cs
+++ b/src/AssemblyGenerator.Parameters.cs
@@ -29,15 +29,20 @@ namespace Lokad.ILPack
                     throw new InvalidOperationException("Duplicate emit of parameter");
                 }
 
-                parameterDef =
-                    _metadata.Builder.AddParameter(parameter.Attributes, _metadata.GetOrAddString(parameter.Name), i);
+                parameterDef = _metadata.Builder.AddParameter(
+                    parameter.Attributes, 
+                    _metadata.GetOrAddString(parameter.Name), 
+                    i+1         // As per EMCA335 II.22.33 sequence numbers are one based for parameters
+                                // and zero refers to the return value.  Without this parameter attributes
+                                // get applied to the wrong parameter.
+                );
 
                 System.Diagnostics.Debug.Assert(parameterDef == MetadataTokens.ParameterHandle(_nextParameterRowId));
 
-                _nextParameterRowId++;
-
                 _metadata.AddParameterHandle(parameter, parameterDef);
-                CreateCustomAttributes(parameterDef, parameter.GetCustomAttributesData());
+                //CreateCustomAttributes(parameterDef, parameter.GetCustomAttributesData());
+
+                _nextParameterRowId++;
             }
 
             return firstHandle;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -167,6 +167,10 @@ namespace Lokad.ILPack
                     }
                 }
             }
+            else if (type.IsGenericParameter)
+            {
+                typeEncoder.GenericTypeParameter(type.GenericParameterPosition);
+            }
             else
             {
                 var typeHandler = metadata.GetTypeHandle(type);

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -148,6 +148,10 @@ namespace Lokad.ILPack
                         ImmutableArray.Create<int>(),
                         ImmutableArray.Create<int>()));
             }
+            else if (type.IsByRef)
+            {
+                throw new InvalidOperationException("ByRef types not allowed in SignatureType encoder (should be handled in calling ParameterEncoder)");
+            }
             else if (type.IsGenericType)
             {
                 var genericTypeDef = type.GetGenericTypeDefinition();
@@ -166,6 +170,10 @@ namespace Lokad.ILPack
                         inst.AddArgument().FromSystemType(ga, metadata);
                     }
                 }
+            }
+            else if (type.IsGenericMethodParameter)
+            {
+                typeEncoder.GenericMethodTypeParameter(type.GenericParameterPosition);
             }
             else if (type.IsGenericParameter)
             {

--- a/src/Lokad.ILPack.csproj
+++ b/src/Lokad.ILPack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -29,7 +29,7 @@ namespace Lokad.ILPack.Metadata
             if (methodInfo.DeclaringType.IsConstructedGenericType)
             {
                 // When calling methods on constructed generic types, the type is the constructed 
-                // type name, but the the method info the method from the open type definition. eg:
+                // type name, but the method info is the method from the open type definition. eg:
                 // 
                 // callvirt instance void class System.Action`1<int32>::Invoke(!0)
                 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^
@@ -44,11 +44,11 @@ namespace Lokad.ILPack.Metadata
                 //                                                             wrong
                 //
                 // There doesn't seem to be a reflection API method to get the definition method.
-                // Note: MethodInfo.GetGenericMethodDefinition won't work here becuase this is a
-                // non-generic method in a generic type.
+                // Note: MethodInfo.GetGenericMethodDefinition won't work here because this is a
+                // non-generic method in a generic type (as opposed to a generic method)
                 // 
-                // Luckily both the original and the constructed method info have the same meta
-                // data token... so we just go to the original generic definition and find the 
+                // Luckily both the original and the constructed type's method have the same meta
+                // data token so we just go to the original generic definition and find the 
                 // method with the same token.
                 //
                 // TODO: What about generic method definitions in a generic type???

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -117,11 +117,6 @@ namespace Lokad.ILPack.Metadata
                 return Builder.AddMethodSpecification(definitionHandle, GetOrAddBlob(enc.Builder));
             }
 
-            if (method.Name == "Invoke" && method.DeclaringType == typeof(Action<int>))
-            {
-                int x = 3;
-            }
-
             var typeRef = ResolveTypeReference(method.DeclaringType);
             var methodRef = Builder.AddMemberReference(typeRef, GetOrAddString(method.Name),
                 GetMethodSignature(method));

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Lokad.ILPack.Metadata
 {
@@ -24,25 +26,62 @@ namespace Lokad.ILPack.Metadata
 
         public BlobHandle GetMethodSignature(MethodInfo methodInfo)
         {
-            var retType = methodInfo.ReturnType;
-            var parameters = methodInfo.GetParameters();
-            var countParameters = parameters.Length;
+            if (methodInfo.DeclaringType.IsConstructedGenericType)
+            {
+                // When calling methods on constructed generic types, the type is the constructed 
+                // type name, but the the method info the method from the open type definition. eg:
+                // 
+                // callvirt instance void class System.Action`1<int32>::Invoke(!0)
+                //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ^
+                //                            constructed type here             |
+                //                                                              |
+                //                    non constructed parameter type here ------+
+                //
+                // ie: NOT this:
+                //
+                // callvirt instance void class System.Action`1<int32>::Invoke(int32)
+                //                                                             ^^^^^
+                //                                                             wrong
+                //
+                // There doesn't seem to be a reflection API method to get the definition method.
+                // Note: MethodInfo.GetGenericMethodDefinition won't work here becuase this is a
+                // non-generic method in a generic type.
+                // 
+                // Luckily both the original and the constructed method info have the same meta
+                // data token... so we just go to the original generic definition and find the 
+                // method with the same token.
+                //
+                // TODO: What about generic method definitions in a generic type???
+                System.Diagnostics.Debug.Assert(!methodInfo.IsGenericMethod);
 
-            var blob = MetadataHelper.BuildSignature(x => x.MethodSignature(
+                var definition = methodInfo.DeclaringType.GetGenericTypeDefinition();
+                methodInfo = definition.GetMethods().Single(x => x.MetadataToken == methodInfo.MetadataToken);
+            }
+
+            // Get parameters
+            var parameters = methodInfo.GetParameters();
+
+            // Create method signature encoder
+            var enc = new BlobEncoder(new BlobBuilder())
+                .MethodSignature(
                     MetadataHelper.ConvertCallingConvention(methodInfo.CallingConvention),
-                    isInstanceMethod: !methodInfo.IsStatic)
-                .Parameters(
-                    countParameters,
-                    r => r.FromSystemType(retType, this),
-                    p =>
+                    isInstanceMethod: !methodInfo.IsStatic);
+
+            // Add return type and parameters
+            enc.Parameters(
+                    parameters.Length,
+                    (retEnc) => retEnc.FromSystemType(methodInfo.ReturnType, this),
+                    (parEnc) =>
                     {
                         foreach (var par in parameters)
                         {
-                            var parEncoder = p.AddParameter();
-                            parEncoder.Type().FromSystemType(par.ParameterType, this);
+                            parEnc.AddParameter().Type().FromSystemType(par.ParameterType, this);
                         }
-                    }));
-            return GetOrAddBlob(blob);
+                    }
+                );
+
+            // Get blob
+            return GetOrAddBlob(enc.Builder);
         }
 
         private EntityHandle ResolveMethodReference(MethodInfo method)
@@ -54,9 +93,33 @@ namespace Lokad.ILPack.Metadata
                     nameof(method));
             }
 
+            // Already created?
             if (_methodRefHandles.TryGetValue(method, out var handle))
             {
                 return handle;
+            }
+
+            // Constructed generic method?
+            if (method.IsConstructedGenericMethod)
+            {
+                // Get the definition handle
+                var definition = method.GetGenericMethodDefinition();
+                var definitionHandle = ResolveMethodReference(definition);
+
+                // Create method spec encoder
+                var enc = new BlobEncoder(new BlobBuilder()).MethodSpecificationSignature(definition.GetGenericArguments().Length);
+                foreach (var a in method.GetGenericArguments())
+                {
+                    enc.AddArgument().FromSystemType(a, this);
+                }
+
+                // Add method spec
+                return Builder.AddMethodSpecification(definitionHandle, GetOrAddBlob(enc.Builder));
+            }
+
+            if (method.Name == "Invoke" && method.DeclaringType == typeof(Action<int>))
+            {
+                int x = 3;
             }
 
             var typeRef = ResolveTypeReference(method.DeclaringType);

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -8,13 +8,6 @@ namespace Lokad.ILPack.Metadata
     {
         public EntityHandle GetTypeHandle(Type type)
         {
-            if (type.IsGenericType && !type.IsGenericTypeDefinition)
-            {
-                var typeSpecEncoder = new BlobEncoder(new BlobBuilder()).TypeSpecificationSignature();
-                typeSpecEncoder.FromSystemType(type, this);
-                return Builder.AddTypeSpecification(GetOrAddBlob(typeSpecEncoder.Builder));
-            }
-
             if (TryGetTypeDefinition(type, out var metadata))
             {
                 return metadata.Handle;
@@ -48,9 +41,16 @@ namespace Lokad.ILPack.Metadata
                     nameof(type));
             }
 
-            if (_typeRefHandles.TryGetValue(type.GUID, out var typeRef))
+            if (_typeRefHandles.TryGetValue(type, out var typeRef))
             {
                 return typeRef;
+            }
+
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                var typeSpecEncoder = new BlobEncoder(new BlobBuilder()).TypeSpecificationSignature();
+                typeSpecEncoder.FromSystemType(type, this);
+                return Builder.AddTypeSpecification(GetOrAddBlob(typeSpecEncoder.Builder));
             }
 
             var scope = GetResolutionScopeForType(type);
@@ -59,7 +59,7 @@ namespace Lokad.ILPack.Metadata
                 GetOrAddString(type.Namespace),
                 GetOrAddString(type.Name));
 
-            _typeRefHandles.Add(type.GUID, typeHandle);
+            _typeRefHandles.Add(type, typeHandle);
 
             // Create all public constructor references
             foreach (var ctor in type.GetConstructors())
@@ -76,13 +76,13 @@ namespace Lokad.ILPack.Metadata
             int propertyIndex, int methodIndex, int eventIndex)
         {
             var metadata = new TypeDefinitionMetadata(type, handle, fieldIndex, propertyIndex, methodIndex, eventIndex);
-            _typeDefHandles.Add(type.GUID, metadata);
+            _typeDefHandles.Add(type, metadata);
             return metadata;
         }
 
         public bool TryGetTypeDefinition(Type type, out TypeDefinitionMetadata metadata)
         {
-            return _typeDefHandles.TryGetValue(type.GUID, out metadata);
+            return _typeDefHandles.TryGetValue(type, out metadata);
         }
     }
 }

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -18,8 +18,8 @@ namespace Lokad.ILPack.Metadata
         private readonly Dictionary<ParameterInfo, ParameterHandle> _parameterHandles;
         private readonly Dictionary<PropertyInfo, PropertyDefinitionMetadata> _propertyHandles;
         private readonly Dictionary<EventInfo, EventDefinitionMetadata> _eventHandles;
-        private readonly Dictionary<Guid, TypeDefinitionMetadata> _typeDefHandles;
-        private readonly Dictionary<Guid, TypeReferenceHandle> _typeRefHandles;
+        private readonly Dictionary<Type, TypeDefinitionMetadata> _typeDefHandles;
+        private readonly Dictionary<Type, TypeReferenceHandle> _typeRefHandles;
 
         public AssemblyMetadata(Assembly sourceAssembly)
         {
@@ -37,8 +37,8 @@ namespace Lokad.ILPack.Metadata
             _parameterHandles = new Dictionary<ParameterInfo, ParameterHandle>();
             _propertyHandles = new Dictionary<PropertyInfo, PropertyDefinitionMetadata>();
             _eventHandles = new Dictionary<EventInfo, EventDefinitionMetadata>();
-            _typeDefHandles = new Dictionary<Guid, TypeDefinitionMetadata>();
-            _typeRefHandles = new Dictionary<Guid, TypeReferenceHandle>();
+            _typeDefHandles = new Dictionary<Type, TypeDefinitionMetadata>();
+            _typeRefHandles = new Dictionary<Type, TypeReferenceHandle>();
 
             CreateReferencedAssemblies(SourceAssembly.GetReferencedAssemblies());
         }

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -15,6 +15,7 @@ namespace Lokad.ILPack.Metadata
         private readonly Dictionary<FieldInfo, MemberReferenceHandle> _fieldRefHandles;
         private readonly Dictionary<MethodInfo, MethodBaseDefinitionMetadata> _methodDefHandles;
         private readonly Dictionary<MethodInfo, MemberReferenceHandle> _methodRefHandles;
+        private readonly Dictionary<MethodInfo, MethodSpecificationHandle> _methodSpecHandles;
         private readonly Dictionary<ParameterInfo, ParameterHandle> _parameterHandles;
         private readonly Dictionary<PropertyInfo, PropertyDefinitionMetadata> _propertyHandles;
         private readonly Dictionary<EventInfo, EventDefinitionMetadata> _eventHandles;
@@ -34,6 +35,7 @@ namespace Lokad.ILPack.Metadata
             _fieldRefHandles = new Dictionary<FieldInfo, MemberReferenceHandle>();
             _methodDefHandles = new Dictionary<MethodInfo, MethodBaseDefinitionMetadata>();
             _methodRefHandles = new Dictionary<MethodInfo, MemberReferenceHandle>();
+            _methodSpecHandles = new Dictionary<MethodInfo, MethodSpecificationHandle>();
             _parameterHandles = new Dictionary<ParameterInfo, ParameterHandle>();
             _propertyHandles = new Dictionary<PropertyInfo, PropertyDefinitionMetadata>();
             _eventHandles = new Dictionary<EventInfo, EventDefinitionMetadata>();


### PR DESCRIPTION
This PR fixes the RewriteTest.InvokeIntParamEventWithNoListeners test case.

Some comments:

* The main change is in GetMethodSignature and there's a hefty comment there describing the change. Also cleaned up the code around the MethodSignature encoder to make it a bit easier to read.

* I've changed the Type to metadata dictionaries from <Guid, ...> to to <Type, ...> because constructed generic types have the same guid as their definition which was causing conflicts.

* Updated the signature encoder to support generic parameters (eg: <T>)

* Also added some improved support for invoking generic methods.  Seems to be correct according to ildasm but haven't been able to confirm in unit test yet due to other issues.

* Some of the reflection API's required for handling generics aren't available in netstandard2.0 so had to  remove it from target frameworks.  Perhaps netstandard 2.1 will help?

* Moved some previously submitted generic handling code from GetTypeHandle to lower level ResolveTypeReference

* Added support for `ref` and `out` parameters.

* Fixed wrong sequence number on parameters (should be one based, not zero as zero refers to the return value).

* Test cases for some of this are included in PR #60 

