### PR TITLE
Removed unused properties

### DIFF
--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -142,8 +142,7 @@ namespace Lokad.ILPack
                 MetadataTokens.MethodDefinitionHandle(offset.MethodIndex + 1));
 
             // Add immediately to support self referencing generics
-            _metadata.ReserveTypeDefinition(type, typeHandle, offset.FieldIndex, offset.PropertyIndex,
-                offset.MethodIndex, offset.EventIndex);
+            _metadata.ReserveTypeDefinition(type, typeHandle);
 
             // Handle generics type
             if (type.IsGenericType)

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -72,10 +72,9 @@ namespace Lokad.ILPack.Metadata
             return typeHandle;
         }
 
-        public TypeDefinitionMetadata ReserveTypeDefinition(Type type, TypeDefinitionHandle handle, int fieldIndex,
-            int propertyIndex, int methodIndex, int eventIndex)
+        public TypeDefinitionMetadata ReserveTypeDefinition(Type type, TypeDefinitionHandle handle)
         {
-            var metadata = new TypeDefinitionMetadata(type, handle, fieldIndex, propertyIndex, methodIndex, eventIndex);
+            var metadata = new TypeDefinitionMetadata(type, handle);
             _typeDefHandles.Add(type.GUID, metadata);
             return metadata;
         }

--- a/src/Metadata/Metadata.cs
+++ b/src/Metadata/Metadata.cs
@@ -63,18 +63,8 @@ namespace Lokad.ILPack.Metadata
 
     internal class TypeDefinitionMetadata : DefinitionMetadata<Type, EntityHandle>
     {
-        public TypeDefinitionMetadata(Type type, EntityHandle handle, int fieldIndex, int propertyIndex,
-            int methodIndex, int eventIndex) : base(type, handle)
+        public TypeDefinitionMetadata(Type type, EntityHandle handle) : base(type, handle)
         {
-            FieldIndex = fieldIndex;
-            PropertyIndex = propertyIndex;
-            MethodIndex = methodIndex;
-            EventIndex = eventIndex;
         }
-
-        public int FieldIndex { get; }
-        public int PropertyIndex { get; }
-        public int MethodIndex { get; }
-        public int EventIndex { get; }
     }
 }


### PR DESCRIPTION
I noticed these unused TypeDefinitionMetadata.xxxIndex properties the other day when adding support for event maps.  If these are intended for some future purpose, please disregard the PR.