### PR TITLE
Fix issues with types loaded through assembly type forwarding

### DIFF
--- a/src/Lokad.ILPack.csproj
+++ b/src/Lokad.ILPack.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR resolves issues with emitting references to forwarded types, including but not limited to forwards from System.Runtime to System.Private.Core.

It works, by reading the metadata for all referenced assemblies, extracting all the forwarded types and creating a map of the forward type to the original assembly that forwarded it.  This lets us emit type references to the forwarding assembly instead of the implementation assembly.

Unfortunately, this requires unsafe code to be enabled as we need Assembly.TryGetRawMetadata which returns a pointer.

Note that this change breaks all unit tests if not combined with PR #55 (because of special handling required for byref parameters to prevent it looking for an assembly reference that doesn't exist)