### PR TITLE
Fixed generic method signature encoding

### DIFF
--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -65,6 +65,7 @@ namespace Lokad.ILPack.Metadata
             var enc = new BlobEncoder(new BlobBuilder())
                 .MethodSignature(
                     MetadataHelper.ConvertCallingConvention(methodInfo.CallingConvention),
+                    genericParameterCount: methodInfo.GetGenericArguments().Length,
                     isInstanceMethod: !methodInfo.IsStatic);
 
             // Add return type and parameters


### PR DESCRIPTION
This fixes calling of imported generic methods from other assemblies.  

eg: `T System.Threading.Interlocked.CompareExchange<T>(T&, T, T)` can now be successfully called.

This, together with other pending pull requests, fixes event firing in the rewritten `TestSubject` assembly and all unit tests (except those commented out) now pass!