### PR TITLE
Fix for AssemblyGeneratorTests randomly failing

### DIFF
--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -15,8 +15,9 @@ namespace Lokad.ILPack.Tests
     {
         private static string SerializeAssembly(Assembly asm, string fileName)
         {
-            var current = Directory.GetCurrentDirectory();
-            var path = Path.Combine(current, fileName);
+            var outdir = Path.Combine(Directory.GetCurrentDirectory(), "generated");
+            Directory.CreateDirectory(outdir);
+            var path = Path.Combine(outdir, fileName);
 
             var generator = new AssemblyGenerator();
             generator.GenerateAssembly(asm, path);


### PR DESCRIPTION
When running under Visual Studio the tests in AssemblyGeneratorTest class often fail with file access errors when trying to save the generated assembly.   Not sure exactly why but I suspect Visual Studio might be watching this folder for changes and load modified DLL's causing the write conflict.

Putting all the output files in a `/generated` sub-folder seems to fix it.