### PR TITLE
Added Sandbox project

### DIFF
--- a/Lokad.ILPack.sln
+++ b/Lokad.ILPack.sln
@@ -9,6 +9,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lokad.ILPack.Tests", "test\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RewriteOriginal", "test\RewriteOriginal\RewriteOriginal.csproj", "{2B12E3D8-796A-4300-AE55-E151D0A129B8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox", "test\Sandbox\Sandbox.csproj", "{131BC75C-C3FA-4202-AFB2-71B576375064}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SandboxSubject", "test\SandboxSubject\SandboxSubject.csproj", "{07C62161-827E-4E66-96C7-BC0E8C5CB759}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sandbox.", "Sandbox.", "{75C16393-4067-483D-95D1-8234549804AE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,9 +33,21 @@ Global
 		{2B12E3D8-796A-4300-AE55-E151D0A129B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B12E3D8-796A-4300-AE55-E151D0A129B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B12E3D8-796A-4300-AE55-E151D0A129B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{131BC75C-C3FA-4202-AFB2-71B576375064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{131BC75C-C3FA-4202-AFB2-71B576375064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{131BC75C-C3FA-4202-AFB2-71B576375064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{131BC75C-C3FA-4202-AFB2-71B576375064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07C62161-827E-4E66-96C7-BC0E8C5CB759}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07C62161-827E-4E66-96C7-BC0E8C5CB759}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07C62161-827E-4E66-96C7-BC0E8C5CB759}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07C62161-827E-4E66-96C7-BC0E8C5CB759}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{131BC75C-C3FA-4202-AFB2-71B576375064} = {75C16393-4067-483D-95D1-8234549804AE}
+		{07C62161-827E-4E66-96C7-BC0E8C5CB759} = {75C16393-4067-483D-95D1-8234549804AE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A7A07076-50CC-434F-ACAE-6E87A4733F67}

--- a/src/Properties/InternalsVisibleTo.cs
+++ b/src/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Lokad.ILPack.Tests")]
+[assembly: InternalsVisibleTo("Sandbox")]

--- a/test/Sandbox/.gitignore
+++ b/test/Sandbox/.gitignore
@@ -1,0 +1,2 @@
+il.*.txt
+md.*.txt

--- a/test/Sandbox/Program.cs
+++ b/test/Sandbox/Program.cs
@@ -49,31 +49,31 @@ namespace Sandbox
 
         async Task<object> Invoke(string setup, string resultExpression)
         {
-            try
-            {
+            var script = CSharpScript
+                .Create($"var x = new MyClass();",
+                        ScriptOptions.Default
+                            .WithReferences(_assembly)
+                            .WithImports(_namespaceName)
+                            )
+                .ContinueWith(setup)
+                .ContinueWith(resultExpression);
 
-                var script = CSharpScript
-                    .Create($"var x = new MyClass();",
-                            ScriptOptions.Default
-                                .WithReferences(_assembly)
-                                .WithImports(_namespaceName)
-                                )
-                    .ContinueWith(setup)
-                    .ContinueWith(resultExpression);
-
-                return (await script.RunAsync()).ReturnValue;
-            }
-            catch (Exception x)
-            {
-                Console.WriteLine(x.Message);
-                throw;
-            }
+            return (await script.RunAsync()).ReturnValue;
         }
 
 
         static void Main(string[] args)
         {
-            new Program().Run();
+            try
+            {
+                new Program().Run();
+            }
+            catch (Exception x)
+            {
+                Console.WriteLine(x.Message);
+                Console.WriteLine(x.StackTrace);
+                throw;
+            }
         }
 
         async void Run()
@@ -115,7 +115,7 @@ namespace Sandbox
             // Invoke the cloned assembly...
 
             var result = await Invoke(
-                $"int r = MyClass.StaticGenericMethod<int>(36);",
+                $"int r = await x.AsyncMethod(30, 30);",
                 "r");
 
             Console.WriteLine(result);

--- a/test/Sandbox/Program.cs
+++ b/test/Sandbox/Program.cs
@@ -1,0 +1,124 @@
+﻿// #define USE_ORIGINAL_SANDBOXSUBJECT
+
+using Lokad.ILPack;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+/*
+ * Sandbox
+ *
+ * This is intended as a place to work on problem areas that currently aren't even
+ * stable enough to write unit tests for yet.
+ * 
+ * In particular if something in the TestSubject project causes ILPack to throw an
+ * exception, all the unit tests will fail since the re-written assembly isn't produced.
+ * The idea is to work on these kinds of problems here and once working, move the test
+ * code into the unit tests.
+ * 
+ * Other advantages to Sandbox over unit tests:
+ * 
+ *  - SandboxSubject can be kept very small and targeted to a particular problem allowing 
+ *    for easier inspection of ildasm/mddumper analysis
+ *    
+ *  - Quick F5 debug/fix/re-run cycle (instead of selecting a specific unit test to run)
+ * 
+ * Sandbox works almost identically to the RewriteTest cases - it rewrites a test assembly
+ * (in this case SandboxSubject) and then invokes it with CSharpScript.
+ * 
+ * Use the `dump.bat` script to produce ildasm and mddumper listings for original and
+ * cloned assemblies. (requires those tools on your path)
+ * 
+ * Uncomment the #define at the top of this file this to test against the original 
+ * SandboxSubject instead of the cloned one. (to test your test case)
+ * 
+ */
+ 
+namespace Sandbox
+{
+    class Program
+    {
+        string _namespaceName;
+        string _assembly;
+        Assembly _asmOriginal;
+        Assembly _asmCloned;
+
+
+        async Task<object> Invoke(string setup, string resultExpression)
+        {
+            try
+            {
+
+                var script = CSharpScript
+                    .Create($"var x = new MyClass();",
+                            ScriptOptions.Default
+                                .WithReferences(_assembly)
+                                .WithImports(_namespaceName)
+                                )
+                    .ContinueWith(setup)
+                    .ContinueWith(resultExpression);
+
+                return (await script.RunAsync()).ReturnValue;
+            }
+            catch (Exception x)
+            {
+                Console.WriteLine(x.Message);
+                throw;
+            }
+        }
+
+
+        static void Main(string[] args)
+        {
+            new Program().Run();
+        }
+
+        async void Run()
+        {
+            // Get the original assembly
+            _asmOriginal = typeof(SandboxSubject.MyClass).Assembly;
+            _asmCloned = typeof(SandboxSubject.MyClass).Assembly;
+            var originalAssembly = _asmOriginal.Location;
+
+
+#if USE_ORIGINAL_SANDBOXSUBJECT
+
+            _namespaceName = "SandboxSubject";
+            _assembly = originalAssembly;
+
+#else
+
+            // Generate the cloned assembly
+            // NB: putting it in the "cloned" sub directory prevents an
+            //     issue with someone (VisStudio perhaps) having the file open
+            //     and preventing rewrite on subsequent run. 
+            var outDir = Path.Join(Path.GetDirectoryName(originalAssembly), "cloned");
+            Directory.CreateDirectory(outDir);
+            var clonedAssembly = Path.Join(outDir, "ClonedSandboxSubject.dll");
+
+            // Rewrite it (renaming the assembly and namespaces in the process)
+            var generator = new AssemblyGenerator();
+            generator.RenameForTesting("SandboxSubject", "ClonedSandboxSubject");
+            generator.GenerateAssembly(_asmOriginal, clonedAssembly);
+
+            _namespaceName = "ClonedSandboxSubject";
+            _assembly = clonedAssembly;
+
+            _asmCloned = Assembly.LoadFrom(_assembly);
+
+#endif
+
+
+            // Invoke the cloned assembly...
+
+            var result = await Invoke(
+                $"int r = MyClass.StaticGenericMethod<int>(36);",
+                "r");
+
+            Console.WriteLine(result);
+        }
+    }
+}

--- a/test/Sandbox/Sandbox.csproj
+++ b/test/Sandbox/Sandbox.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Lokad.ILPack.csproj" />
+    <ProjectReference Include="..\SandboxSubject\SandboxSubject.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+  </ItemGroup>
+
+
+  </Project>

--- a/test/Sandbox/asm.bat
+++ b/test/Sandbox/asm.bat
@@ -1,0 +1,1 @@
+ilasm /dll il.clone.txt /output=bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll

--- a/test/Sandbox/dump.bat
+++ b/test/Sandbox/dump.bat
@@ -1,0 +1,4 @@
+ildasm /bytes bin\Debug\netcoreapp2.1\SandboxSubject.dll > il.original.txt
+ildasm /bytes bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll > il.clone.txt
+mddumper bin\Debug\netcoreapp2.1\SandboxSubject.dll > md.original.txt
+mddumper bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll > md.clone.txt

--- a/test/SandboxSubject/MyClass.cs
+++ b/test/SandboxSubject/MyClass.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace SandboxSubject
+{
+    public class MyClass
+    {
+        public static T StaticGenericMethod<T>(T x)
+        {
+            return x;
+        }
+
+        /*
+        public static void StaticGenericMethodWithByRef<T>(ref T x, ref T y)
+        {
+            T temp = x;
+            x = y;
+            y = temp;
+        }
+
+        public T GenericMethod<T>(T x)
+        {
+            return x;
+        }
+
+        public void GenericMethodWithByRef<T>(ref T x, ref T y)
+        {
+            T temp = x;
+            x = y;
+            y = temp;
+        }
+
+        public async Task<int> AsyncMethod(int x, int y)
+        {
+            await Task.Delay(100);
+            return x + y;
+        }
+        */
+    }
+}

--- a/test/SandboxSubject/MyClass.cs
+++ b/test/SandboxSubject/MyClass.cs
@@ -1,39 +1,15 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace SandboxSubject
 {
     public class MyClass
     {
-        public static T StaticGenericMethod<T>(T x)
-        {
-            return x;
-        }
-
-        /*
-        public static void StaticGenericMethodWithByRef<T>(ref T x, ref T y)
-        {
-            T temp = x;
-            x = y;
-            y = temp;
-        }
-
-        public T GenericMethod<T>(T x)
-        {
-            return x;
-        }
-
-        public void GenericMethodWithByRef<T>(ref T x, ref T y)
-        {
-            T temp = x;
-            x = y;
-            y = temp;
-        }
 
         public async Task<int> AsyncMethod(int x, int y)
         {
             await Task.Delay(100);
             return x + y;
         }
-        */
     }
 }

--- a/test/SandboxSubject/SandboxSubject.csproj
+++ b/test/SandboxSubject/SandboxSubject.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Explanation comment from Sandbox/Program.cs copied below...

---

This is intended as a place to work on problem areas that currently aren't even
stable enough to write unit tests for yet.

In particular if something in the TestSubject project causes ILPack to throw an
exception, all the unit tests will fail since the re-written assembly isn't produced.
The idea is to work on these kinds of problems here and once working, move the test
code into the unit tests.

Other advantages to Sandbox over unit tests:

 - SandboxSubject can be kept very small and targeted to a particular problem allowing 
   for easier inspection of ildasm/mddumper analysis
   
 - Quick F5 debug/fix/re-run cycle (instead of having to select a specific unit test to run)

Sandbox works almost identically to the RewriteTest cases - it rewrites a test assembly
(in this case SandboxSubject) and then invokes it with CSharpScript.

Use the `dump.bat` script to produce ildasm and mddumper listings for original and
cloned assemblies. (requires those tools on your path)

Uncomment the #define at the top of this file this to test against the original 
SandboxSubject instead of the cloned one. (to test your test case)
