### PR TITLE
Handle types forwarded by multiple referenced assemblies

### DIFF
--- a/src/Metadata/AssemblyMetadata.Assemblies.cs
+++ b/src/Metadata/AssemblyMetadata.Assemblies.cs
@@ -87,7 +87,9 @@ namespace Lokad.ILPack.Metadata
                     {
                         var name = mdr.GetString(et.Name);
                         var ns = mdr.GetString(et.Namespace);
-                        _reverseForwardingMap.Add($"{ns}.{name}", asmName);
+                        var key = $"{ns}.{name}";
+                        if (!_reverseForwardingMap.ContainsKey(key))
+                            _reverseForwardingMap.Add(key, asmName);
                     }
                 }
             }


### PR DESCRIPTION
eg: System.AggregateException is forwarded by both
System.Threading.Tasks and System.Runtime