### PR TITLE
Use SZArray instead of shaped arrays for single rank arrays.

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -144,12 +144,19 @@ namespace Lokad.ILPack
             {
                 var elementType = type.GetElementType();
 
-                typeEncoder.Array(
-                    x => x.FromSystemType(elementType, metadata),
-                    x => x.Shape(
-                        type.GetArrayRank(),
-                        ImmutableArray.Create<int>(),
-                        ImmutableArray.Create<int>()));
+                if (type.GetArrayRank() == 1)
+                {
+                    typeEncoder.SZArray().FromSystemType(elementType, metadata);
+                }
+                else
+                {
+                    typeEncoder.Array(
+                        x => x.FromSystemType(elementType, metadata),
+                        x => x.Shape(
+                            type.GetArrayRank(),
+                            ImmutableArray.Create<int>(),
+                            ImmutableArray.Create<int>()));
+                }
             }
             else if (type.IsByRef)
             {


### PR DESCRIPTION
This is a small tweak to generate signatures that better match what the C# compiler produces.

SZArrays are essentially a short cut for a one-dimensional, zero based array shape.

No unit test for this because runtime result doesn't change. Can be confirmed in ildasm listing by checking single dimension arrays appearing as `[]` instead of `[...]`.

