### PR TITLE
Fix to tag PropDefs with instance flag

### DIFF
--- a/src/AssemblyGenerator.Properties.cs
+++ b/src/AssemblyGenerator.Properties.cs
@@ -17,7 +17,12 @@ namespace Lokad.ILPack
             var countParameters = parameters.Length;
             var retType = propertyInfo.PropertyType;
 
-            var blob = MetadataHelper.BuildSignature(x => x.PropertySignature()
+            // Work out if this is an instance property
+            var eitherAccessor = propertyInfo.GetGetMethod() ?? propertyInfo.GetSetMethod();
+            System.Diagnostics.Debug.Assert(eitherAccessor != null);
+            var isInstanceProperty = eitherAccessor.CallingConvention.HasFlag(CallingConventions.HasThis);
+
+            var blob = MetadataHelper.BuildSignature(x => x.PropertySignature(isInstanceProperty)
                 .Parameters(
                     countParameters,
                     r => r.FromSystemType(retType, _metadata),


### PR DESCRIPTION
No unit tests for this because .NET doesn't actually require this flag on the prop def (it figures it out from the accessor methods), but this is more correct.

See also, the "note" in EMCA 335 under "Property : 0x17", top of pp242