### PR TITLE
Fixes for generic value types

### DIFF
--- a/src/AssemblyGenerator.Constructors.cs
+++ b/src/AssemblyGenerator.Constructors.cs
@@ -31,7 +31,7 @@ namespace Lokad.ILPack
                 ctor.Attributes,
                 ctor.MethodImplementationFlags,
                 _metadata.GetOrAddString(ctor.Name),
-                _metadata.GetConstructorSignature(ctor),
+                _metadata.GetMethodOrConstructorSignature(ctor),
                 bodyOffset,
                 parameters);
 

--- a/src/AssemblyGenerator.Methods.cs
+++ b/src/AssemblyGenerator.Methods.cs
@@ -34,7 +34,7 @@ namespace Lokad.ILPack
                 offset = methodBodyWriter.AddMethodBody(method);
             }
 
-            var signature = _metadata.GetMethodSignature(method);
+            var signature = _metadata.GetMethodOrConstructorSignature(method);
             var parameters = CreateParameters(method.GetParameters());
 
             var handle = _metadata.Builder.AddMethodDefinition(

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -168,7 +168,7 @@ namespace Lokad.ILPack
                 var typeHandler = metadata.GetTypeHandle(genericTypeDef);
                 var genericArguments = type.GetGenericArguments();
 
-                var inst = typeEncoder.GenericInstantiation(typeHandler, genericArguments.Length, false);
+                var inst = typeEncoder.GenericInstantiation(typeHandler, genericArguments.Length, type.IsValueType);
                 foreach (var ga in genericArguments)
                 {
                     if (ga.IsGenericParameter)

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -59,14 +59,6 @@ namespace Lokad.ILPack.Metadata
 
             _typeRefHandles.Add(type, typeHandle);
 
-            // Create all public constructor references
-            foreach (var ctor in type.GetConstructors())
-            {
-                var signature = GetConstructorSignature(ctor);
-                var ctorRef = Builder.AddMemberReference(typeHandle, GetOrAddString(ctor.Name), signature);
-                _ctorRefHandles.Add(ctor, ctorRef);
-            }
-
             return typeHandle;
         }
 


### PR DESCRIPTION
Fixes for various issues with generic value types, generic constructors, and signature encoding for generic types.

- refactored method and constructor signature encoding into a single shared function
- fixed type encoder handling of generic value types, incorrectly encoding as reference types
- updated constructor handling to more closely mirror method handling
- removed code to pre-create constructor references.  Not sure why needed, now uses same approach as methods and all unit tests still pass.

These changes are enough for nullable value types to work.  Will include unit tests once PR #81 has been merged.