### PR TITLE
Fix attribute arrays, fix incorrectly emitting base fields and events, tests

### DIFF
--- a/src/AssemblyGenerator.Events.cs
+++ b/src/AssemblyGenerator.Events.cs
@@ -7,9 +7,9 @@ namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
-        private readonly BindingFlags AllEvents =
+        private const BindingFlags AllEvents =
             BindingFlags.NonPublic | BindingFlags.Public |
-            BindingFlags.Instance | BindingFlags.Static;
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
         private void CreateEvent(EventInfo ev, bool addToEventMap)
         {

--- a/src/AssemblyGenerator.Properties.cs
+++ b/src/AssemblyGenerator.Properties.cs
@@ -7,9 +7,9 @@ namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
-        private readonly BindingFlags AllProperties =
+        private const BindingFlags AllProperties =
             BindingFlags.NonPublic | BindingFlags.Public |
-            BindingFlags.Instance | BindingFlags.Static;
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
         private BlobHandle GetPropertySignature(PropertyInfo propertyInfo)
         {

--- a/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
@@ -28,5 +28,31 @@ namespace Lokad.ILPack.Tests
             Assert.Equal(titleOriginal.Title, titleClone.Title);
         }
 
+        [Fact]
+        public async void AttributePlacedArrayValues()
+        {
+            Assert.Equal(new int[] { 10, 20, 30 } , await Invoke(
+                $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeArrayTest\").GetCustomAttribute<MyAttribute>();",
+                "attr.Values"
+                ));
+        }
+
+        [Fact]
+        public async void AttributeNamedValue()
+        {
+            Assert.Equal("ILPack", await Invoke(
+                $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeArrayTest\").GetCustomAttribute<MyAttribute>();",
+                "attr.Named"
+                ));
+        }
+
+        [Fact]
+        public async void AttributeNamedArrayValues()
+        {
+            Assert.Equal(new int[] { 40, 50, 60 }, await Invoke(
+                $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeArrayTest\").GetCustomAttribute<MyAttribute>();",
+                "attr.NamedArray"
+                ));
+        }
     }
 }

--- a/test/Lokad.ILPack.Tests/RewriteTest.Nullable.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Nullable.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+
+namespace Lokad.ILPack.Tests
+{
+    partial class RewriteTest
+    {
+        [Fact]
+        public async void Nullable()
+        {
+            Assert.Equal(false, await Invoke(
+                $"var r = x.GetNullable();",
+                "r"
+            ));
+        }
+    }
+}

--- a/test/Lokad.ILPack.Tests/RewriteTest._boot.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest._boot.cs
@@ -86,7 +86,7 @@ namespace Lokad.ILPack.Tests
                 .Create($"var x = new MyClass();", 
                         ScriptOptions.Default
                             .WithReferences(_assembly)
-                            .WithImports(_namespaceName)
+                            .WithImports(_namespaceName, "System.Reflection")
                         )
                 .ContinueWith(setup)
                 .ContinueWith(resultExpression);

--- a/test/TestSubject/MyAttribute.cs
+++ b/test/TestSubject/MyAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestSubject
+{
+    public class MyAttribute : Attribute
+    {
+        public int[] Values { get; set; }
+
+        public MyAttribute(params int[] values)
+        {
+           this.Values = values;
+        }
+
+        public string Named { get; set; }
+
+        public int[] NamedArray { get; set; }
+    }   
+}

--- a/test/TestSubject/MyClass.Attributes.cs
+++ b/test/TestSubject/MyClass.Attributes.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+
+// This project defines a set of types that will be rewritten by the test cases to a new
+// dll named "ClonedTestSubject".  The test cases then compare the final type information of both
+// assemblies to confirm everything was re-written correction
+
+// SEE RewriteTest in Lokad.ILPack.Tests
+
+
+namespace TestSubject
+{
+    public partial class MyClass
+    {
+        [MyAttribute(
+            10, 20, 30, 
+            Named = "ILPack", 
+            NamedArray = new int[] { 40, 50, 60 } 
+            )]
+        public void AttributeArrayTest()
+        {
+        }
+    }
+}

--- a/test/TestSubject/MyClass.Nullable.cs
+++ b/test/TestSubject/MyClass.Nullable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+
+// This project defines a set of types that will be rewritten by the test cases to a new
+// dll named "ClonedTestSubject".  The test cases then compare the final type information of both
+// assemblies to confirm everything was re-written correction
+
+// SEE RewriteTest in Lokad.ILPack.Tests
+
+
+namespace TestSubject
+{
+    public partial class MyClass
+    {
+        bool? _nullableBool = false;
+
+        public bool? GetNullable()
+        {
+            return _nullableBool;
+        }
+    }
+}


### PR DESCRIPTION
- Added support for attribute arrays (both placed and named), with unit tests
- Added support for custom attributes
- Fix for incorrectly emitting base fields and events (required for previous to work)
- Unit test for Nullable types (held back unit test for PR#82)