### PR TITLE
Fix method parameter position encoding

### DIFF
--- a/src/IL/MethodBodyWriter.cs
+++ b/src/IL/MethodBodyWriter.cs
@@ -9,6 +9,17 @@ namespace Lokad.ILPack.IL
 {
     internal static class MethodBodyWriter
     {
+        private static int GetParameterPosition(ParameterInfo parameterInfo)
+        {
+            var method = parameterInfo.Member as MethodBase;
+            if (method == null)
+            {
+                throw new ArgumentException("Declaring constructor or method cannot be null.", nameof(parameterInfo));
+            }
+
+            return parameterInfo.Position + (method.IsStatic ? 0 : 1);
+        }
+
         public static void Write(IAssemblyMetadata metadata, IReadOnlyList<Instruction> il)
         {
             for (var i = 0; i < il.Count; i++)
@@ -122,7 +133,7 @@ namespace Lokad.ILPack.IL
                         }
                         else if (bParameterInfo != null)
                         {
-                            metadata.ILBuilder.WriteByte((byte) bParameterInfo.Position);
+                            metadata.ILBuilder.WriteByte((byte) GetParameterPosition(bParameterInfo));
                         }
                         else
                         {
@@ -141,7 +152,7 @@ namespace Lokad.ILPack.IL
                         }
                         else if (sParameterInfo != null)
                         {
-                            metadata.ILBuilder.WriteUInt16((ushort) sParameterInfo.Position);
+                            metadata.ILBuilder.WriteUInt16((ushort) GetParameterPosition(sParameterInfo));
                         }
                         else
                         {

--- a/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using Xunit;
 
 
@@ -32,5 +33,20 @@ namespace Lokad.ILPack.Tests
                 "r"));
         }
 
+        [Fact]
+        public async void AnotherMethodWithDifferentParameterTypes7()
+        {
+            Assert.Equal(CancellationToken.None, await Invoke(
+                "var r = x.AnotherMethodWithDifferentParameterTypes7(false, 1.0f, 2, 3, 4, new object(), System.Threading.CancellationToken.None);",
+                "r"));
+
+            Assert.Equal(9, await Invoke(
+                "var r = x.AnotherMethodWithDifferentParameterTypes7(true, 1.0f, 2, 3, 4, null, System.Threading.CancellationToken.None);",
+                "r"));
+
+            Assert.Equal(10, await Invoke(
+                "var r = x.AnotherMethodWithDifferentParameterTypes7(true, 1.0f, 2, 3, 4, new object(), System.Threading.CancellationToken.None);",
+                "r"));
+        }
     }
 }

--- a/test/TestSubject/MyClass.Methods.cs
+++ b/test/TestSubject/MyClass.Methods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading;
 
 // This project defines a set of types that will be rewritten by the test cases to a new
 // dll named "ClonedTestSubject".  The test cases then compare the final type information of both
@@ -38,5 +37,15 @@ namespace TestSubject
             return a + b;
         }
 
+        public object AnotherMethodWithDifferentParameterTypes7(bool a, float b, int c0, int c1, int c2, object d,
+            CancellationToken e)
+        {
+            return AnotherMethodWithDifferentParameterTypes3(a, c0 + c1 + c2 + (d != null ? (int) b : 0), e);
+        }
+
+        public object AnotherMethodWithDifferentParameterTypes3(bool a, int c, CancellationToken e)
+        {
+            return a ? c : (object) e;
+        }
     }
 }


### PR DESCRIPTION
Fixes method parameter position encoding for methods with more than 4 parameters (including `this` for instance methods). Includes relevant unit tests.

Resolves: #84