### PR TITLE
Generation of Exception Region Tables

### DIFF
--- a/src/IL/ExceptionRegionEncoder.cs
+++ b/src/IL/ExceptionRegionEncoder.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+
+namespace Lokad.ILPack.IL
+{
+    // From: http://source.roslyn.codeplex.com/#System.Reflection.Metadata/System/Reflection/Metadata/Ecma335/Encoding/ExceptionRegionEncoder.cs,8b29240f3cf4bc5e
+
+    public readonly struct ExceptionRegionEncoder
+    {
+        private const int TableHeaderSize = 4;
+ 
+        private const int SmallRegionSize =
+            sizeof(short) +  // Flags
+            sizeof(short) +  // TryOffset
+            sizeof(byte) +   // TryLength
+            sizeof(short) +  // HandlerOffset
+            sizeof(byte) +   // HandleLength
+            sizeof(int);     // ClassToken | FilterOffset
+ 
+        private const int FatRegionSize =
+            sizeof(int) +    // Flags
+            sizeof(int) +    // TryOffset
+            sizeof(int) +    // TryLength
+            sizeof(int) +    // HandlerOffset
+            sizeof(int) +    // HandleLength
+            sizeof(int);     // ClassToken | FilterOffset
+ 
+        private const int ThreeBytesMaxValue = 0xffffff;
+        internal const int MaxSmallExceptionRegions = (byte.MaxValue - TableHeaderSize) / SmallRegionSize;
+        internal const int MaxExceptionRegions = (ThreeBytesMaxValue - TableHeaderSize) / FatRegionSize;
+ 
+        /// <summary>
+        /// The underlying builder.
+        /// </summary>
+        public BlobBuilder Builder { get; }
+ 
+        /// <summary>
+        /// True if the encoder uses small format.
+        /// </summary>
+        public bool HasSmallFormat { get; }
+ 
+        internal ExceptionRegionEncoder(BlobBuilder builder, bool hasSmallFormat)
+        {
+            Builder = builder;
+            HasSmallFormat = hasSmallFormat;
+        }
+ 
+        /// <summary>
+        /// Returns true if the number of exception regions first small format.
+        /// </summary>
+        /// <param name="exceptionRegionCount">Number of exception regions.</param>
+        public static bool IsSmallRegionCount(int exceptionRegionCount) =>
+            unchecked((uint)exceptionRegionCount) <= MaxSmallExceptionRegions;
+ 
+        /// <summary>
+        /// Returns true if the region fits small format.
+        /// </summary>
+        /// <param name="startOffset">Start offset of the region.</param>
+        /// <param name="length">Length of the region.</param>
+        public static bool IsSmallExceptionRegion(int startOffset, int length) => 
+            unchecked((uint)startOffset) <= ushort.MaxValue && unchecked((uint)length) <= byte.MaxValue;
+ 
+        internal static bool IsSmallExceptionRegionFromBounds(int startOffset, int endOffset) => 
+            IsSmallExceptionRegion(startOffset, endOffset - startOffset);
+ 
+        internal static int GetExceptionTableSize(int exceptionRegionCount, bool isSmallFormat) => 
+            TableHeaderSize + exceptionRegionCount * (isSmallFormat ? SmallRegionSize : FatRegionSize);
+ 
+        internal static bool IsExceptionRegionCountInBounds(int exceptionRegionCount) => 
+            unchecked((uint)exceptionRegionCount) <= MaxExceptionRegions;
+ 
+        internal static bool IsValidCatchTypeHandle(EntityHandle catchType)
+        {
+            return !catchType.IsNil &&
+                   (catchType.Kind == HandleKind.TypeDefinition ||
+                    catchType.Kind == HandleKind.TypeSpecification ||
+                    catchType.Kind == HandleKind.TypeReference);
+        }
+ 
+        internal static ExceptionRegionEncoder SerializeTableHeader(BlobBuilder builder, int exceptionRegionCount, bool hasSmallRegions)
+        {
+            Debug.Assert(exceptionRegionCount > 0);
+ 
+            const byte EHTableFlag = 0x01;
+            const byte FatFormatFlag = 0x40;
+ 
+            bool hasSmallFormat = hasSmallRegions && IsSmallRegionCount(exceptionRegionCount);
+            int dataSize = GetExceptionTableSize(exceptionRegionCount, hasSmallFormat);
+ 
+            builder.Align(4);
+            if (hasSmallFormat)
+            {
+                builder.WriteByte(EHTableFlag);
+                builder.WriteByte(unchecked((byte)dataSize));
+                builder.WriteInt16(0);
+            }
+            else
+            {
+                Debug.Assert(dataSize <= 0x00ffffff);
+                builder.WriteByte(EHTableFlag | FatFormatFlag);
+                builder.WriteByte(unchecked((byte)dataSize));
+                builder.WriteUInt16(unchecked((ushort)(dataSize >> 8)));
+            }
+ 
+            return new ExceptionRegionEncoder(builder, hasSmallFormat);
+        }
+ 
+        /// <summary>
+        /// Adds a finally clause.
+        /// </summary>
+        /// <param name="tryOffset">Try block start offset.</param>
+        /// <param name="tryLength">Try block length.</param>
+        /// <param name="handlerOffset">Handler start offset.</param>
+        /// <param name="handlerLength">Handler length.</param>
+        /// <returns>Encoder for the next clause.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="tryOffset"/>, <paramref name="tryLength"/>, <paramref name="handlerOffset"/> or <paramref name="handlerLength"/> is out of range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Method body was not declared to have exception regions.</exception>
+        public ExceptionRegionEncoder AddFinally(int tryOffset, int tryLength, int handlerOffset, int handlerLength)
+        {
+            return Add(ExceptionRegionKind.Finally, tryOffset, tryLength, handlerOffset, handlerLength, default(EntityHandle), 0);
+        }
+ 
+        /// <summary>
+        /// Adds a fault clause.
+        /// </summary>
+        /// <param name="tryOffset">Try block start offset.</param>
+        /// <param name="tryLength">Try block length.</param>
+        /// <param name="handlerOffset">Handler start offset.</param>
+        /// <param name="handlerLength">Handler length.</param>
+        /// <returns>Encoder for the next clause.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="tryOffset"/>, <paramref name="tryLength"/>, <paramref name="handlerOffset"/> or <paramref name="handlerLength"/> is out of range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Method body was not declared to have exception regions.</exception>
+        public ExceptionRegionEncoder AddFault(int tryOffset, int tryLength, int handlerOffset, int handlerLength)
+        {
+            return Add(ExceptionRegionKind.Fault, tryOffset, tryLength, handlerOffset, handlerLength, default(EntityHandle), 0);
+        }
+ 
+        /// <summary>
+        /// Adds a fault clause.
+        /// </summary>
+        /// <param name="tryOffset">Try block start offset.</param>
+        /// <param name="tryLength">Try block length.</param>
+        /// <param name="handlerOffset">Handler start offset.</param>
+        /// <param name="handlerLength">Handler length.</param>
+        /// <param name="catchType">
+        /// <see cref="TypeDefinitionHandle"/>, <see cref="TypeReferenceHandle"/> or <see cref="TypeSpecificationHandle"/>.
+        /// </param>
+        /// <returns>Encoder for the next clause.</returns>
+        /// <exception cref="ArgumentException"><paramref name="catchType"/> is invalid.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="tryOffset"/>, <paramref name="tryLength"/>, <paramref name="handlerOffset"/> or <paramref name="handlerLength"/> is out of range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Method body was not declared to have exception regions.</exception>
+        public ExceptionRegionEncoder AddCatch(int tryOffset, int tryLength, int handlerOffset, int handlerLength, EntityHandle catchType)
+        {
+            return Add(ExceptionRegionKind.Catch, tryOffset, tryLength, handlerOffset, handlerLength, catchType, 0);
+        }
+ 
+        /// <summary>
+        /// Adds a fault clause.
+        /// </summary>
+        /// <param name="tryOffset">Try block start offset.</param>
+        /// <param name="tryLength">Try block length.</param>
+        /// <param name="handlerOffset">Handler start offset.</param>
+        /// <param name="handlerLength">Handler length.</param>
+        /// <param name="filterOffset">Offset of the filter block.</param>
+        /// <returns>Encoder for the next clause.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="tryOffset"/>, <paramref name="tryLength"/>, <paramref name="handlerOffset"/> or <paramref name="handlerLength"/> is out of range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Method body was not declared to have exception regions.</exception>
+        public ExceptionRegionEncoder AddFilter(int tryOffset, int tryLength, int handlerOffset, int handlerLength, int filterOffset)
+        {
+            return Add(ExceptionRegionKind.Filter, tryOffset, tryLength, handlerOffset, handlerLength, default(EntityHandle), filterOffset);
+        }
+ 
+        /// <summary>
+        /// Adds an exception clause.
+        /// </summary>
+        /// <param name="kind">Clause kind.</param>
+        /// <param name="tryOffset">Try block start offset.</param>
+        /// <param name="tryLength">Try block length.</param>
+        /// <param name="handlerOffset">Handler start offset.</param>
+        /// <param name="handlerLength">Handler length.</param>
+        /// <param name="catchType">
+        /// <see cref="TypeDefinitionHandle"/>, <see cref="TypeReferenceHandle"/> or <see cref="TypeSpecificationHandle"/>, 
+        /// or nil if <paramref name="kind"/> is not <see cref="ExceptionRegionKind.Catch"/>
+        /// </param>
+        /// <param name="filterOffset">
+        /// Offset of the filter block, or 0 if the <paramref name="kind"/> is not <see cref="ExceptionRegionKind.Filter"/>.
+        /// </param>
+        /// <returns>Encoder for the next clause.</returns>
+        /// <exception cref="ArgumentException"><paramref name="catchType"/> is invalid.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="kind"/> has invalid value.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="tryOffset"/>, <paramref name="tryLength"/>, <paramref name="handlerOffset"/> or <paramref name="handlerLength"/> is out of range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Method body was not declared to have exception regions.</exception>
+        public ExceptionRegionEncoder Add(
+            ExceptionRegionKind kind,
+            int tryOffset,
+            int tryLength,
+            int handlerOffset,
+            int handlerLength,
+            EntityHandle catchType = default(EntityHandle),
+            int filterOffset = 0)
+        {
+            if (Builder == null)
+            {
+                throw new InvalidOperationException("Method has no exception regions");
+            }
+ 
+            if (HasSmallFormat)
+            {
+                if (unchecked((ushort)tryOffset) != tryOffset) throw new ArgumentOutOfRangeException(nameof(tryOffset));
+                if (unchecked((byte)tryLength) != tryLength) throw new ArgumentOutOfRangeException(nameof(tryLength));
+                if (unchecked((ushort)handlerOffset) != handlerOffset) throw new ArgumentOutOfRangeException(nameof(handlerOffset));
+                if (unchecked((byte)handlerLength) != handlerLength) throw new ArgumentOutOfRangeException(nameof(handlerLength));
+            }
+            else
+            {
+                if (tryOffset < 0) throw new ArgumentOutOfRangeException(nameof(tryOffset));
+                if (tryLength < 0) throw new ArgumentOutOfRangeException(nameof(tryLength));
+                if (handlerOffset < 0) throw new ArgumentOutOfRangeException(nameof(handlerOffset));
+                if (handlerLength < 0) throw new ArgumentOutOfRangeException(nameof(handlerLength));
+            }
+ 
+            int catchTokenOrOffset;
+            switch (kind)
+            {
+                case ExceptionRegionKind.Catch:
+                    if (!IsValidCatchTypeHandle(catchType))
+                    {
+                        throw new ArgumentException(nameof(catchType));
+                    }
+ 
+                    catchTokenOrOffset = MetadataTokens.GetToken(catchType);
+                    break;
+ 
+                case ExceptionRegionKind.Filter:
+                    if (filterOffset < 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(filterOffset));
+                    }
+ 
+                    catchTokenOrOffset = filterOffset;
+                    break;
+ 
+                case ExceptionRegionKind.Finally:
+                case ExceptionRegionKind.Fault:
+                    catchTokenOrOffset = 0;
+                    break;
+ 
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+ 
+            AddUnchecked(kind, tryOffset, tryLength, handlerOffset, handlerLength, catchTokenOrOffset);
+            return this;
+        }
+ 
+        internal void AddUnchecked(
+            ExceptionRegionKind kind,
+            int tryOffset,
+            int tryLength,
+            int handlerOffset,
+            int handlerLength,
+            int catchTokenOrOffset)
+        {
+            if (HasSmallFormat)
+            {
+                Builder.WriteUInt16((ushort)kind);
+                Builder.WriteUInt16((ushort)tryOffset);
+                Builder.WriteByte((byte)tryLength);
+                Builder.WriteUInt16((ushort)handlerOffset);
+                Builder.WriteByte((byte)handlerLength);
+            }
+            else
+            {
+                Builder.WriteInt32((int)kind);
+                Builder.WriteInt32(tryOffset);
+                Builder.WriteInt32(tryLength);
+                Builder.WriteInt32(handlerOffset);
+                Builder.WriteInt32(handlerLength);
+            }
+ 
+            Builder.WriteInt32(catchTokenOrOffset);
+        }
+    }
+}

--- a/src/IL/MethodBodyStreamWriter.cs
+++ b/src/IL/MethodBodyStreamWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
@@ -25,10 +26,10 @@ namespace Lokad.ILPack.IL
             }
 
             var localVariables = body.LocalVariables.ToArray();
-			var localEncoder = new BlobEncoder(new BlobBuilder()).LocalVariableSignature(localVariables.Length);
+            var localEncoder = new BlobEncoder(new BlobBuilder()).LocalVariableSignature(localVariables.Length);
             foreach (var l in localVariables)
             {
-                localEncoder.AddVariable().Type().FromSystemType(l.LocalType, _metadata); 
+                localEncoder.AddVariable().Type().FromSystemType(l.LocalType, _metadata);
             }
 
             var instructions = methodBase.GetInstructions();
@@ -39,11 +40,57 @@ namespace Lokad.ILPack.IL
             var localVariablesSignature = _metadata.AddStandAloneSignature(localEncoder.Builder);
             var hasDynamicStackAllocation = instructions.Any(x => x.OpCode == OpCodes.Localloc);
 
-            var offset = SerializeHeader(codeSize, maxStack, exceptionRegionCount, attributes, localVariablesSignature,
-                hasDynamicStackAllocation);
+            // Header
+            var offset = SerializeHeader(codeSize, maxStack, exceptionRegionCount, attributes, localVariablesSignature, hasDynamicStackAllocation);
 
+            // Instructions
             MethodBodyWriter.Write(_metadata, instructions);
+
+            // Exceptions
+            SerializeExceptionRegions(body);
+
             return offset;
+        }
+
+        private void SerializeExceptionRegions(MethodBody body)
+        {
+            // Get exception clauses, quit if none
+            var clauses = body.ExceptionHandlingClauses;
+            if (clauses.Count == 0)
+                return;
+
+            // Can we use a small exception table?
+            var useSmallTable = HasSmallExceptionRegions(body.ExceptionHandlingClauses);
+
+            // Align to 4 byte boundary
+            var exre = ExceptionRegionEncoder.SerializeTableHeader(_metadata.ILBuilder, clauses.Count, useSmallTable);
+            foreach (var ex in body.ExceptionHandlingClauses)
+            {
+                exre.Add((ExceptionRegionKind)ex.Flags, ex.TryOffset, ex.TryLength, ex.HandlerOffset, ex.HandlerLength,
+                    ex.Flags == ExceptionHandlingClauseOptions.Clause ? _metadata.GetTypeHandle(ex.CatchType) : default(EntityHandle),
+                    ex.Flags == ExceptionHandlingClauseOptions.Filter ? ex.FilterOffset : 0);
+            }
+        }
+
+        private bool HasSmallExceptionRegions(IList<ExceptionHandlingClause> clauses)
+        {
+            System.Diagnostics.Debug.Assert(clauses != null);
+ 
+            if (!ExceptionRegionEncoder.IsSmallRegionCount(clauses.Count))
+            {
+                return false;
+            }
+ 
+            foreach (var clause in clauses)
+            {
+                if (!ExceptionRegionEncoder.IsSmallExceptionRegion(clause.TryOffset, clause.TryLength) ||
+                    !ExceptionRegionEncoder.IsSmallExceptionRegion(clause.HandlerOffset, clause.HandlerLength))
+                {
+                    return false;
+                }
+            }
+ 
+            return true;
         }
 
         // Adapted from: https://github.com/dotnet/corefx/blob/772a2486f2dd29f3a0401427a26da23e845a6e59/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/MethodBodyStreamEncoder.cs#L222-L272

--- a/test/Lokad.ILPack.Tests/RewriteTest.Exceptions.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Exceptions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+
+namespace Lokad.ILPack.Tests
+{
+    partial class RewriteTest
+    {
+        [Fact]
+        public async void ThrowGuardedException()
+        {
+            Assert.Equal(true, await Invoke(
+                $"var r = x.ThrowGuardedException();",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void ThrowGuardedExceptionWithFinally()
+        {
+            Assert.Equal(0b0000_0111, await Invoke(
+                $"int r = 0; x.ThrowGuardedExceptionWithFinally(ref r);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void ThrowNestedGuardedExceptionWithFinally()
+        {
+            Assert.Equal(0b0111_0111, await Invoke(
+                $"int r = 0; x.ThrowNestedGuardedExceptionWithFinally(ref r);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void ThrowGuardedExceptionWithUntypedCatchAndFinally()
+        {
+            Assert.Equal(0b0000_0111, await Invoke(
+                $"int r = 0; x.ThrowGuardedExceptionWithUntypedCatchAndFinally(ref r);",
+                "r"
+                ));
+        }
+
+
+    }
+}

--- a/test/TestSubject/MyClass.Exceptions.cs
+++ b/test/TestSubject/MyClass.Exceptions.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Threading.Tasks;
+
+// This project defines a set of types that will be rewritten by the test cases to a new
+// dll named "ClonedTestSubject".  The test cases then compare the final type information of both
+// assemblies to confirm everything was re-written correction
+
+// SEE RewriteTest in Lokad.ILPack.Tests
+
+
+namespace TestSubject
+{
+    public partial class MyClass
+    {
+        public bool ThrowGuardedException()
+        {
+            try
+            {
+                throw new InvalidOperationException();
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+        }
+
+        public void ThrowGuardedExceptionWithFinally(ref int hitPoints)
+        {
+            try
+            {
+                hitPoints |= 0b0000_0001;
+                throw new InvalidOperationException();
+            }
+            catch (InvalidOperationException)
+            {
+                hitPoints |= 0b0000_0010;
+                return;
+            }
+            finally
+            {
+                hitPoints |= 0b0000_0100;
+            }
+        }
+
+        public void ThrowNestedGuardedExceptionWithFinally(ref int hitPoints)
+        {
+            try
+            {
+
+                hitPoints |= 0b0000_0001;
+
+                try
+                {
+                    hitPoints |= 0b0001_0000;
+                    throw new InvalidOperationException();
+                }
+                catch (InvalidOperationException)
+                {
+                    hitPoints |= 0b0010_0000;
+                    throw;
+                }
+                finally
+                {
+                    hitPoints |= 0b0100_0000;
+                }
+
+            }
+            catch (InvalidOperationException)
+            {
+                hitPoints |= 0b0000_0010;
+                return;
+            }
+            finally
+            {
+                hitPoints |= 0b0000_0100;
+            }
+        }
+
+
+        public void ThrowGuardedExceptionWithUntypedCatchAndFinally(ref int hitPoints)
+        {
+            try
+            {
+                hitPoints |= 0b0000_0001;
+                throw new InvalidOperationException();
+            }
+            catch
+            {
+                hitPoints |= 0b0000_0010;
+                return;
+            }
+            finally
+            {
+                hitPoints |= 0b0000_0100;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Unfortunately had to lift source code for ExceptionRegionEncoder because required entry point to use it is internal in Reflection.Metadata.Emca335. 

Test cases included