### PR TITLE
Various fixes for arrays

### DIFF
--- a/src/AssemblyGenerator.Fields.cs
+++ b/src/AssemblyGenerator.Fields.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 
 namespace Lokad.ILPack
 {
@@ -30,6 +33,37 @@ namespace Lokad.ILPack
             metadata.MarkAsEmitted();
 
             CreateCustomAttributes(handle, field.GetCustomAttributesData());
+
+            if (field.IsStatic && (field.Attributes & FieldAttributes.HasFieldRVA) != 0)
+            {
+                // HasFieldRVA fields are used by C# for static array initializers 
+                // (eg: x = new int { 1,2,3}).  The easiest way to understand these is to
+                // look at an ildasm dump, but basically it creates a static field initialized
+                // to point to a blob of data (via the RVA)
+                // 
+                // There's no reflection API to get the raw bytes from the RVA so we
+                // author a little dynamic method to grab it.  This code basically mirrors
+                // what C# generates for array initializers.
+
+                // Allocate memory for the initialization data
+                var bytes = new byte[Marshal.SizeOf(field.FieldType)];
+
+                // Create a dynamic method
+                var method = new DynamicMethod("getInitData", typeof(void), new System.Type[] {typeof(byte[]) }, true);
+                var il = method.GetILGenerator();
+                il.Emit(OpCodes.Ldarg_0);               // Load "bytes"
+                il.Emit(OpCodes.Ldtoken, field);        // Token for the field
+                il.Emit(OpCodes.Call, typeof(System.Runtime.CompilerServices.RuntimeHelpers).GetMethod("InitializeArray"));
+                il.Emit(OpCodes.Ret);
+                var getInitData = (Action<byte[]>)method.CreateDelegate(typeof(Action<byte[]>));
+
+                // Call it
+                getInitData(bytes);
+
+                // Write the data to the mapped field data builder
+                _metadata.Builder.AddFieldRelativeVirtualAddress(handle, _metadata.MappedFieldDataBuilder.Count);
+                _metadata.MappedFieldDataBuilder.WriteBytes(bytes);
+            }
         }
 
         private void CreateFields(IEnumerable<FieldInfo> fields)

--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -143,6 +143,16 @@ namespace Lokad.ILPack
                 MetadataTokens.FieldDefinitionHandle(offset.FieldIndex + 1),
                 MetadataTokens.MethodDefinitionHandle(offset.MethodIndex + 1));
 
+            // Setup pack and size attributes (if explicit layout)
+            if (type.IsExplicitLayout)
+            {
+                _metadata.Builder.AddTypeLayout(
+                    typeHandle,
+                    (ushort)type.StructLayoutAttribute.Pack,
+                    (uint)type.StructLayoutAttribute.Size
+                    );
+            }
+
             // Add implemented interfaces (not for enums though - eg: IComparable etc...)
             if (!type.IsEnum)
             {

--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -38,6 +38,11 @@ namespace Lokad.ILPack
         // Apply name changes to assembly and namespace names
         internal string ApplyNameChange(string str)
         {
+            // Types can have a null namespace. eg: some compiler generated classes like C#'s  
+            // "<PrivateImplementationDetails>" used for static array initializers
+            if (str == null)
+                return null;
+
             if (_oldName == null)
                 return str;
             else

--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -110,6 +110,7 @@ namespace Lokad.ILPack
                 header,
                 metadataRootBuilder,
                 _metadata.ILBuilder,
+                mappedFieldData: _metadata.MappedFieldDataBuilder,
                 debugDirectoryBuilder: _debugDirectoryBuilder,
                 entryPoint: entryPoint);
 

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -28,6 +28,7 @@ namespace Lokad.ILPack.Metadata
             SourceAssembly = sourceAssembly;
             Builder = new MetadataBuilder();
             ILBuilder = new BlobBuilder();
+            MappedFieldDataBuilder = new BlobBuilder();
 
             _assemblyRefHandles = new Dictionary<string, AssemblyReferenceHandle>();
             _ctorDefHandles = new Dictionary<ConstructorInfo, MethodBaseDefinitionMetadata>();
@@ -47,9 +48,11 @@ namespace Lokad.ILPack.Metadata
             CreateReferencedAssemblies(SourceAssembly.GetReferencedAssemblies());
         }
 
+
         public Assembly SourceAssembly { get; }
         public MetadataBuilder Builder { get; }
         public BlobBuilder ILBuilder { get; }
+        public BlobBuilder MappedFieldDataBuilder { get; }
 
         public UserStringHandle GetOrAddUserString(string value)
         {

--- a/test/Lokad.ILPack.Tests/RewriteTest.Arrays.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Arrays.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+
+namespace Lokad.ILPack.Tests
+{
+    partial class RewriteTest
+    {
+        [Fact]
+        public async void MethodWithSZArray()
+        {
+            Assert.Equal(6, await Invoke(
+                @"var r = x.MethodWithSZArray(new int[] { 1,2,3 });",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodReturningSZArray()
+        {
+            Assert.Equal(new int[] { 1, 2, 3 }, await Invoke(
+                @"var r = x.MethodReturningSZArray();",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodWithMultiDimArray()
+        {
+            Assert.Equal(78, await Invoke(
+                @"
+                    var array = new int[,,]
+                    {
+                        { { 1, 2 }, { 3, 4 }, {5, 6 } },
+                        { { 7, 8 }, { 9, 10 }, {11, 12 } },
+                    };
+                    var r = x.MethodWithMultiDimArray(array);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodReturningMultiDimArray()
+        {
+            var expected = new int[,,]
+            {
+                { { 1, 2 }, { 3, 4 }, {5, 6 } },
+                { { 7, 8 }, { 9, 10 }, {11, 12 } },
+            };
+
+            Assert.Equal(expected, await Invoke(
+                @"var r = x.MethodReturningMultiDimArray();",
+                "r"
+                ));
+        }
+    }
+}

--- a/test/TestSubject/MyClass.Arrays.cs
+++ b/test/TestSubject/MyClass.Arrays.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading.Tasks;
+
+// This project defines a set of types that will be rewritten by the test cases to a new
+// dll named "ClonedTestSubject".  The test cases then compare the final type information of both
+// assemblies to confirm everything was re-written correction
+
+// SEE RewriteTest in Lokad.ILPack.Tests
+
+
+namespace TestSubject
+{
+    public partial class MyClass
+    {
+        public int MethodWithSZArray(int[] vals)
+        {
+            int sum = 0;
+            for (int i = 0; i < vals.Length; i++)
+            {
+                sum += vals[i];
+            }
+            return sum;
+        }
+
+        public int[] MethodReturningSZArray()
+        {
+            return new int[] { 1, 2, 3 };
+        }
+
+        public int MethodWithMultiDimArray(int[,,] vals)
+        {
+            int sum = 0;
+            for (int i = 0; i < vals.GetLength(0); i++)
+            {
+                for (int j = 0; j < vals.GetLength(1); j++)
+                {
+                    for (int k = 0; k < vals.GetLength(2); k++)
+                    {
+                        sum += vals[i, j, k];
+                    }
+                }
+            }
+            return sum;
+        }
+
+        public int[,,] MethodReturningMultiDimArray()
+        {
+            return new int[,,]
+            {
+                { { 1, 2 }, { 3, 4 }, {5, 6 } },
+                { { 7, 8 }, { 9, 10 }, {11, 12 } },
+            };
+        }
+    }
+}


### PR DESCRIPTION
Addresses number of issues related to arrays:

1. Various fixes for multi-dimension arrays
2. Fix for RVA initialized fields as used by C#'s array initializers eg: `var x= new int[] { 1,2,3 }`
3. Fix not setting `size` and `pack` attributes on explicit layout types

Open to suggestions for better way to retrieve the data associated with RVA initialized fields.  Couldn't find anything in .NET's reflection API to extract this data so there's a bit of skulduggery involved with the current approach.  See comments in `AssemblyGenerator.Fields.cs`

Test cases included.