### PR TITLE
Fixes for issues with multi-dim arrays of user defined types

### DIFF
--- a/src/AssemblyGenerator.Constructors.cs
+++ b/src/AssemblyGenerator.Constructors.cs
@@ -26,14 +26,7 @@ namespace Lokad.ILPack
                 localVariablesSignature = _metadata.Builder.AddStandaloneSignature(_metadata.GetOrAddBlob(
                     MetadataHelper.BuildSignature(x =>
                     {
-                        var sig = x.LocalVariableSignature(body.LocalVariables.Count);
-                        foreach (var vrb in body.LocalVariables)
-                        {
-                            sig.AddVariable().Type(
-                                    vrb.LocalType.IsByRef,
-                                    vrb.IsPinned)
-                                .FromSystemType(vrb.LocalType, _metadata);
-                        }
+                        x.LocalVariableSignature(body.LocalVariables.Count).AddRange(body.LocalVariables, _metadata);
                     })));
             }
 

--- a/src/AssemblyGenerator.Methods.cs
+++ b/src/AssemblyGenerator.Methods.cs
@@ -30,14 +30,7 @@ namespace Lokad.ILPack
                 localVariablesSignature = _metadata.Builder.AddStandaloneSignature(_metadata.GetOrAddBlob(
                     MetadataHelper.BuildSignature(x =>
                     {
-                        var sig = x.LocalVariableSignature(body.LocalVariables.Count);
-                        foreach (var vrb in body.LocalVariables)
-                        {
-                            sig.AddVariable().Type(
-                                    vrb.LocalType.IsByRef,
-                                    vrb.IsPinned)
-                                .FromSystemType(vrb.LocalType, _metadata);
-                        }
+                        x.LocalVariableSignature(body.LocalVariables.Count).AddRange(body.LocalVariables, _metadata);
                     })));
             }
 

--- a/src/IL/MethodBodyStreamWriter.cs
+++ b/src/IL/MethodBodyStreamWriter.cs
@@ -27,10 +27,7 @@ namespace Lokad.ILPack.IL
 
             var localVariables = body.LocalVariables.ToArray();
             var localEncoder = new BlobEncoder(new BlobBuilder()).LocalVariableSignature(localVariables.Length);
-            foreach (var l in localVariables)
-            {
-                localEncoder.AddVariable().Type().FromSystemType(l.LocalType, _metadata);
-            }
+            localEncoder.AddRange(localVariables, _metadata);
 
             var instructions = methodBase.GetInstructions();
             var maxStack = body.MaxStackSize;

--- a/src/Metadata/AssemblyMetadata.Constructors.cs
+++ b/src/Metadata/AssemblyMetadata.Constructors.cs
@@ -22,24 +22,24 @@ namespace Lokad.ILPack.Metadata
                 nameof(ctor));
         }
 
-        private EntityHandle ResolveConstructorReference(ConstructorInfo method)
+        private EntityHandle ResolveConstructorReference(ConstructorInfo ctor)
         {
-            if (!IsReferencedType(method.DeclaringType))
+            if (!IsReferencedType(ctor.DeclaringType))
             {
                 throw new ArgumentException(
-                    $"Method of a reference type is expected: {MetadataHelper.GetFriendlyName(method)}",
-                    nameof(method));
+                    $"Method of a reference type is expected: {MetadataHelper.GetFriendlyName(ctor)}",
+                    nameof(ctor));
             }
 
             // Already created?
-            if (_ctorRefHandles.TryGetValue(method, out var handle))
+            if (_ctorRefHandles.TryGetValue(ctor, out var handle))
             {
                 return handle;
             }
 
-            var typeRef = ResolveTypeReference(method.DeclaringType);
-            var methodRef = Builder.AddMemberReference(typeRef, GetOrAddString(method.Name), GetMethodOrConstructorSignature(method));
-            _ctorRefHandles.Add(method, methodRef);
+            var typeRef = ResolveTypeReference(ctor.DeclaringType);
+            var methodRef = Builder.AddMemberReference(typeRef, GetOrAddString(ctor.Name), GetMethodOrConstructorSignature(ctor));
+            _ctorRefHandles.Add(ctor, methodRef);
             return methodRef;
         }
 

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -33,6 +33,10 @@ namespace Lokad.ILPack.Metadata
 
         public bool IsReferencedType(Type type)
         {
+            // Arrays are always referenced types
+            if (type.IsArray)
+                return true;
+
             // todo, also maybe in Module, ModuleRef, AssemblyRef and TypeRef
             // ECMA-335 page 273-274
             return type.Assembly != SourceAssembly;

--- a/test/Lokad.ILPack.Tests/RewriteTest.Arrays.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Arrays.cs
@@ -55,5 +55,85 @@ namespace Lokad.ILPack.Tests
                 "r"
                 ));
         }
-    }
+
+        [Fact]
+        public async void MethodWithJaggedArray()
+        {
+            Assert.Equal(36, await Invoke(
+                @"
+                    var array = new int[][]
+                    {
+                        new int[] { 1, 2, 3, 4, 5, },
+                        new int[] { 10, 11 },
+                    };
+                    var r = x.MethodWithJaggedArray(array);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodReturningJaggedArray()
+        {
+            var expected = new int[][]
+            {
+                new int[] { 1, 2, 3, 4, 5, },
+                new int[] { 10, 11 },
+            };
+            Assert.Equal(expected, await Invoke(
+                @"var r = x.MethodReturningJaggedArray();",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodWithSZArrayOfUserType()
+        {
+            Assert.Equal(21, await Invoke(
+                @"
+                    var array = new MyStruct[]
+                    {
+                        new MyStruct(1, 2),
+                        new MyStruct(3, 4),
+                        new MyStruct(5, 6),
+                    };
+                    var r = x.MethodWithSZArrayOfUserType(array);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodReturningSZArrayOfUserType()
+        {
+            Assert.Equal((3,4), await Invoke(
+                @"
+                var r = x.MethodReturningSZArrayOfUserType();",
+                "(r[1].x, r[1].y)"
+                ));
+        }
+
+
+        [Fact]
+        public async void MethodWithMultiDimArrayOfUserType()
+        {
+            Assert.Equal(36, await Invoke(
+                @"
+                    var array = new MyStruct[,]
+                    {
+                        { new MyStruct(1, 2), new MyStruct(3, 4), },
+                        { new MyStruct(5, 6), new MyStruct(7, 8), }
+                    };
+                    var r = x.MethodWithMultiDimArrayOfUserType(array);",
+                "r"
+                ));
+        }
+
+        [Fact]
+        public async void MethodReturningMultiArrayOfUserType()
+        {
+            Assert.Equal((3,4), await Invoke(
+                @"
+                var r = x.MethodReturningMultiDimArrayOfUserType();",
+                "(r[0,1].x, r[0,1].y)"
+                ));
+        }    }
 }

--- a/test/TestSubject/MyClass.Arrays.cs
+++ b/test/TestSubject/MyClass.Arrays.cs
@@ -51,5 +51,70 @@ namespace TestSubject
                 { { 7, 8 }, { 9, 10 }, {11, 12 } },
             };
         }
+
+        public int MethodWithJaggedArray(int[][] vals)
+        {
+            int sum = 0;
+            for (int i = 0; i < vals.Length; i++)
+            {
+                var row = vals[i];
+                for (var j = 0; j < row.Length; j++)
+                {
+                    sum += row[j];
+                }
+            }
+            return sum;
+        }
+
+        public int[][] MethodReturningJaggedArray()
+        {
+            return new int[][]
+            {
+                new int[] { 1, 2, 3, 4, 5, },
+                new int[] { 10, 11 },
+            };
+        }
+
+        public int MethodWithSZArrayOfUserType(MyStruct[] vals)
+        {
+            int sum = 0;
+            for (int i = 0; i < vals.Length; i++)
+            {
+                sum += vals[i].x + vals[i].y;
+            }
+            return sum;
+        }
+
+        public MyStruct[] MethodReturningSZArrayOfUserType()
+        {
+            return new MyStruct[]
+            {
+                new MyStruct(1, 2),
+                new MyStruct(3, 4),
+                new MyStruct(5, 6),
+            };
+        }
+
+        public int MethodWithMultiDimArrayOfUserType(MyStruct[,] vals)
+        {
+            int sum = 0;
+            for (int i = 0; i < vals.GetLength(0); i++)
+            {
+                for (int j = 0; j < vals.GetLength(1); j++)
+                {
+                    sum += vals[i,j].x + vals[i,j].y;
+                }
+            }
+            return sum;
+        }
+
+        public MyStruct[,] MethodReturningMultiDimArrayOfUserType()
+        {
+            return new MyStruct[,]
+            {
+                { new MyStruct(1, 2), new MyStruct(3, 4), },
+                { new MyStruct(5, 6), new MyStruct(7, 8), }
+            };
+        }
     }
 }


### PR DESCRIPTION
Fixes include:

* Arrays are always imported types, but instantiated array types return the element type assembly as the declaring assembly causing ILPack to think they're non-imported types
* Support for signature encoding when return type is a reference (for multi-dim array `Address` method)
* Refactored local variable signature encoding as affected by changes for previous point and was repeated differently in a few places.
* Tweaked the way multi-dim array shapes are generated to more closely match what C# generates `[0...,0...]` instead of `[,]`

Passing test cases for

* jagged arrays
* single-dim arrays of user defined type
* multi-dim arrays of user defined type
