### PR TITLE
.NET Standard 2.0 & .NET 4.6 Support 

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -221,12 +221,7 @@ namespace Lokad.ILPack
                     }
                 }
             }
-#if NETSTANDARD || NET46
             else if(type.IsGenericMethodParameter())
-
-#else
-            else if (type.IsGenericMethodParameter)
-#endif
             {
                 typeEncoder.GenericMethodTypeParameter(type.GenericParameterPosition);
             }
@@ -291,6 +286,10 @@ namespace Lokad.ILPack
                 return false;
             }
         }
+#else
+        internal static bool IsGenericMethodParameter( this Type type ) => type.IsGenericMethodParameter;
+
+        internal static bool IsConstructedGenericMethod( this MethodBase method ) => method.IsConstructedGenericMethod;
 #endif
     }
 }

--- a/src/Lokad.ILPack.csproj
+++ b/src/Lokad.ILPack.csproj
@@ -22,11 +22,13 @@
     <Version>0.1.0</Version>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="Extensions.cs~RF6a0154.TMP" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />

--- a/src/Lokad.ILPack.csproj
+++ b/src/Lokad.ILPack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net46</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -23,6 +23,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Extensions.cs~RF6a0154.TMP" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
 </Project>

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -118,7 +118,11 @@ namespace Lokad.ILPack.Metadata
             }
 
             // Constructed generic method?
+#if NETSTANDARD || NET46
+            if (method.IsConstructedGenericMethod())
+#else
             if (method.IsConstructedGenericMethod)
+#endif
             {
                 // Already created?
                 if (_methodSpecHandles.TryGetValue(method, out var handle))

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -118,11 +118,7 @@ namespace Lokad.ILPack.Metadata
             }
 
             // Constructed generic method?
-#if NETSTANDARD || NET46
             if (method.IsConstructedGenericMethod())
-#else
-            if (method.IsConstructedGenericMethod)
-#endif
             {
                 // Already created?
                 if (_methodSpecHandles.TryGetValue(method, out var handle))

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -79,7 +79,11 @@ namespace Lokad.ILPack.Metadata
 
         public bool IsGenericTypeSpec(Type type)
         {
+#if NETSTANDARD || NET46
+            return type.IsGenericMethodParameter() || type.IsGenericParameter || (type.IsGenericType && !type.IsGenericTypeDefinition);
+#else
             return type.IsGenericMethodParameter || type.IsGenericParameter || (type.IsGenericType && !type.IsGenericTypeDefinition);
+#endif
         }
 
         private EntityHandle ResolveArrayTypeSpec(Type type)

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -79,11 +79,7 @@ namespace Lokad.ILPack.Metadata
 
         public bool IsGenericTypeSpec(Type type)
         {
-#if NETSTANDARD || NET46
             return type.IsGenericMethodParameter() || type.IsGenericParameter || (type.IsGenericType && !type.IsGenericTypeDefinition);
-#else
-            return type.IsGenericMethodParameter || type.IsGenericParameter || (type.IsGenericType && !type.IsGenericTypeDefinition);
-#endif
         }
 
         private EntityHandle ResolveArrayTypeSpec(Type type)

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -11,8 +11,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="CS-Script" Version="3.29.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting">
+      <Version>2.10.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -11,9 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CS-Script" Version="3.29.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -23,7 +20,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting">
-      <Version>2.10.0</Version>
+      <Version>3.2.1</Version>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="CS-Script" Version="3.29.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/test/Lokad.ILPack.Tests/RewriteTest._boot.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest._boot.cs
@@ -57,9 +57,9 @@ namespace Lokad.ILPack.Tests
             // NB: putting it in the "cloned" sub directory prevents an
             //     issue with someone (VisStudio perhaps) having the file open
             //     and preventing rewrite on subsequent run. 
-            var outDir = Path.Join(Path.GetDirectoryName(originalAssembly), "cloned");
+            var outDir = Path.Combine(Path.GetDirectoryName(originalAssembly), "cloned");
             Directory.CreateDirectory(outDir);
-            var clonedAssembly = Path.Join(outDir, "ClonedTestSubject.dll");
+            var clonedAssembly = Path.Combine(outDir, "ClonedTestSubject.dll");
 
             // Rewrite it (renaming the assembly and namespaces in the process)
             var generator = new AssemblyGenerator();

--- a/test/TestSubject/TestSubject.csproj
+++ b/test/TestSubject/TestSubject.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
I am implementing ways to have this package on .NET Standard & .NET Framework.

I have been able to gather all Metadata and tests partially pass. I would like to discuss a little how to fix the problem I am having with reserved and actual handles. They are not the same on .NET 4.6.

I am trying to use this package on https://github.com/arlm/Sigil-vNext to implement saving the generated Dynamic Assemblies but that does not work for .NET Standard for now and I have not been able to install Lokad.ILPack on any of the targets (The NuGet version targets .NET Core only).