### PR TITLE
Fixed nested type reference issue, improved support for generic methods, improved interface map generation

### DIFF
--- a/src/AssemblyGenerator.Methods.cs
+++ b/src/AssemblyGenerator.Methods.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -57,32 +56,9 @@ namespace Lokad.ILPack
                 offset,
                 parameters);
 
-            // Explicit interface implementations need to be marked with method implementation
-            // (This is the equivalent of .Override in msil)
-            if (method.IsPrivate)
-            {
-                // Go through all the implemented interfaces and all their methods
-                // looking for methods that this method implements and mark accordingly.
-
-                // NB: This is not super efficient.  Should probably create a map somewhere
-                //     for faster lookup, but this will do for now.
-
-                var type = method.DeclaringType;
-                foreach (var itf in type.GetInterfaces())
-                {
-                    var itfMap = type.GetInterfaceMap(itf);
-                    for (int i = 0; i < itfMap.TargetMethods.Length; i++)
-                    {
-                        var m = itfMap.TargetMethods[i];
-                        if (m == method)
-                        {
-                            var itfImpl = itfMap.InterfaceMethods[i];
-                            _metadata.Builder.AddMethodImplementation((TypeDefinitionHandle)_metadata.GetTypeHandle(method.DeclaringType), handle, _metadata.GetMethodHandle(itfImpl));
-
-                        }
-                    }
-                }
-            }
+            // The generation of interface method overrides has been moved to 
+            // AssemblyGenerator.DeclareInterfacesAndCreateInterfaceMap in
+            // AssemblyGenerator.Types.cs.
 
             // Add generic parameters
             if (method.IsGenericMethodDefinition)

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -211,7 +211,11 @@ namespace Lokad.ILPack
                 var inst = typeEncoder.GenericInstantiation(typeHandler, genericArguments.Length, type.IsValueType);
                 foreach (var ga in genericArguments)
                 {
-                    if (ga.IsGenericParameter)
+                    if (ga.IsGenericMethodParameter())
+                    {
+                        inst.AddArgument().GenericMethodTypeParameter(ga.GenericParameterPosition);
+                    }
+                    else if (ga.IsGenericParameter)
                     {
                         inst.AddArgument().GenericTypeParameter(ga.GenericParameterPosition);
                     }
@@ -221,7 +225,7 @@ namespace Lokad.ILPack
                     }
                 }
             }
-            else if(type.IsGenericMethodParameter())
+            else if (type.IsGenericMethodParameter())
             {
                 typeEncoder.GenericMethodTypeParameter(type.GenericParameterPosition);
             }


### PR DESCRIPTION
- Fixed the nested type reference issue. The scope of a nested type is its declaring type, not the assembly.
- Fixed an issue with parameter declarations of generic methods. `Extensions.FromSystemType` now uses `SignatureTypeEncoder.GenericMethodTypeParameter` or `SignatureTypeEncodes.GenericTypeParameter` depending on whether the generic type argument is declared by a method or by a type.
- The declared interfaces were reduced to those interfaces that are not already declared by the base type. This prevents the generation of dependencies not covered by the `GetReferencedAssemblies` method.
- The generation of the interface map has been moved from AssemblyGenerator.Methods.cs to AssemblyGenerator.Types.cs. This covers cases where base type methods are used to implement methods of newly declared interfaces. This is not possible using C#, but it can be done using msil or by dynamically generating types with System.Reflection.Emit.