### PR TITLE
Added support for default parameter values

### DIFF
--- a/src/AssemblyGenerator.Parameters.cs
+++ b/src/AssemblyGenerator.Parameters.cs
@@ -37,6 +37,12 @@ namespace Lokad.ILPack
                                 // get applied to the wrong parameter.
                 );
 
+                // If the parameter has a default value add the value to the constants table.
+                // Use the parameter handle as the parent of the value in the constants table
+                // as specified in ECMA335 II.22.9.
+                if (parameter.HasDefaultValue)
+                    _metadata.Builder.AddConstant(parameterDef, parameter.RawDefaultValue);
+
                 System.Diagnostics.Debug.Assert(parameterDef == MetadataTokens.ParameterHandle(_nextParameterRowId));
 
                 _metadata.AddParameterHandle(parameter, parameterDef);

--- a/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
@@ -45,5 +45,48 @@ namespace Lokad.ILPack.Tests
                 "var r = x.AnotherMethodWithDifferentParameterTypes7(true, 1.0f, 2, 3, 4, new object(), System.Threading.CancellationToken.None);",
                 "r"));
         }
+
+        [Fact]
+        public async void AnotherMethodWithDefaultParameterValues()
+        {
+            Assert.Equal("Hallo, world!", await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(0);",
+                "r"));
+            Assert.Equal(string.Empty, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(0, \"\");",
+                "r"));
+            Assert.Equal(string.Empty, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(0, \"\", \"\");",
+                "r"));
+            Assert.Equal(string.Empty, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(0, \"\", \"\", 27);",
+                "r"));
+
+            Assert.Null(await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(1);",
+                "r"));
+            Assert.Null(await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(1, \"\");",
+                "r"));
+            Assert.Equal("Hallo, world!", await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(1, \"\", \"Hallo, world!\");",
+                "r"));
+            Assert.Equal("Hallo, world!", await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(1, \"\", \"Hallo, world!\", 27);",
+                "r"));
+
+            Assert.Equal(4711, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(2);",
+                "r"));
+            Assert.Equal(4711, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(2, \"\");",
+                "r"));
+            Assert.Equal(4711, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(2, \"\", \"\");",
+                "r"));
+            Assert.Equal(27, await Invoke(
+                "var r = x.AnotherMethodWithDefaultParameterValues(2, \"\", \"\", 27);",
+                "r"));
+        }
     }
 }

--- a/test/TestSubject/MyClass.Methods.cs
+++ b/test/TestSubject/MyClass.Methods.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 // This project defines a set of types that will be rewritten by the test cases to a new
 // dll named "ClonedTestSubject".  The test cases then compare the final type information of both
@@ -46,6 +47,24 @@ namespace TestSubject
         public object AnotherMethodWithDifferentParameterTypes3(bool a, int c, CancellationToken e)
         {
             return a ? c : (object) e;
+        }
+
+        public object AnotherMethodWithDefaultParameterValues(int a, string b = "Hallo, world!", string c = null, int d = 4711)
+        {
+            switch (a)
+            {
+                case 0:
+                    return b;
+
+                case 1:
+                    return c;
+
+                case 2:
+                    return d;
+
+                default:
+                    throw new ArgumentException(nameof(a));
+            }
         }
     }
 


### PR DESCRIPTION
Added support for default parameter values according to ECMA335 II.22.9 by adding default values of method parameters to the constants table. A test method for this feature has also been created.