### PR TITLE
Fix AssemblyAttribute defined and applied

### DIFF
--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -103,8 +103,6 @@ namespace Lokad.ILPack
                 ConvertGeneratedAssemblyNameFlags(name),
                 ConvertAssemblyHashAlgorithm(name.HashAlgorithm));
 
-            CreateCustomAttributes(assemblyHandle, assembly.GetCustomAttributesData());
-
             // Add "<Module>" type definition *before* any type definition.
             //
             // TODO: [osman] methodList argument should be as following:
@@ -123,6 +121,8 @@ namespace Lokad.ILPack
                 MetadataTokens.MethodDefinitionHandle(1));
 
             CreateModules(_metadata.SourceAssembly.GetModules());
+
+            CreateCustomAttributes(assemblyHandle, assembly.GetCustomAttributesData());
 
             MethodDefinitionHandle entryPoint = default;
             if (_metadata.SourceAssembly.EntryPoint != null &&

--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -498,6 +498,32 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
+        public void TestAssemblyAttribute()
+        {
+            // Define assembly and module
+            var assemblyName = new AssemblyName { Name = "MyAssembly" };
+            var newAssembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var newModule = newAssembly.DefineDynamicModule("MyModule");
+
+            // [assembly: CustomAttribute]
+            // [AttributeUsage(AttributeTargets.Assembly)]
+            // public class CustomAttribute : Attribute { }
+            var attributeTypeBuilder = newModule.DefineType("CustomAttribute", TypeAttributes.Public | TypeAttributes.Class, typeof(Attribute));
+            _ = attributeTypeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+
+            // Add [AttributeUsage(AttributeTargets.Assembly)]
+            var attributeUsageTypeInfo = typeof(AttributeUsageAttribute).GetTypeInfo();
+            var attributeUsageConstructorInfo = attributeUsageTypeInfo.GetConstructor(new[] { typeof(AttributeTargets) });
+            attributeTypeBuilder.SetCustomAttribute(new CustomAttributeBuilder(attributeUsageConstructorInfo, new object[] { AttributeTargets.Assembly }));
+
+            // apply to assembly
+            var attributeConstructor = attributeTypeBuilder.CreateTypeInfo().GetConstructor(Array.Empty<Type>());
+            newAssembly.SetCustomAttribute(new CustomAttributeBuilder(attributeConstructor, Array.Empty<Object>()));
+
+            SerializeAndVerifyAssembly(newAssembly, "AssemblyAttribute.dll");
+        }
+
+        [Fact]
         public void TestTypeSerialization()
         {
             // create assembly name


### PR DESCRIPTION
This fixes an `ArgumentException System.ArgumentException : Type cannot be found`
when generating an assembly that both defines and applies an assembly level
custom attribute.