### PR TITLE
Support interfaces implementing interfaces

### DIFF
--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -171,6 +171,13 @@ namespace Lokad.ILPack
                 _metadata.Builder.AddInterfaceImplementation(handle, _metadata.GetTypeHandle(ifc));
             }
 
+            // If the type is an interface they may be no interface map.
+            // TODO: This isn't necessarily true for Default interface methods.
+            if (type.IsInterface)
+            {
+                return;
+            }
+
             // Build the interface map.
             // All interfaces need to be considered (not just the ones added by the type) because
             // the type may override interface methods of interfaces implemented by the base type.

--- a/test/TestSubject/MyClass.Interfaces.cs
+++ b/test/TestSubject/MyClass.Interfaces.cs
@@ -35,6 +35,9 @@ namespace TestSubject
     interface Itf2
     {
     }
+    interface Itf3 : Itf2
+    {
+    }
 
     /// <summary> Challenging the interface metadata ordering. </summary>
     class MyImpl : Itf2, Itf1


### PR DESCRIPTION
Declared interfaces that implement interfaces currently fail when building the interface map. Instead of trying to build the map, mark the type implements the interface and then skip over handling mapping.