### PR TITLE
Handle some pseudo attributes during serialization.

### DIFF
--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -4,17 +4,34 @@ using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
 
 namespace Lokad.ILPack
 {
     public partial class AssemblyGenerator
     {
+        // TODO: This list is not exhaustive
+        static readonly HashSet<Type> s_PseudoAttributes = new HashSet<Type>()
+        {
+            typeof(DllImportAttribute),
+            typeof(ComImportAttribute),
+            typeof(PreserveSigAttribute)
+        };
+
         public void CreateCustomAttributes(EntityHandle parent, IEnumerable<CustomAttributeData> attributes)
         {
             foreach (var attr in attributes)
             {
                 // Get the attribute type and make sure handle created
                 var attrType = attr.AttributeType;
+
+                // Check if the supplied attribute should be emitted or is encoded
+                // directly in metadata.
+                if (s_PseudoAttributes.Contains(attrType))
+                {
+                    continue;
+                }
+
                 var attrTypeHandle = _metadata.GetTypeHandle(attrType); // create type
 
                 // Get handle to the constructor

--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -171,7 +171,7 @@ namespace Lokad.ILPack
                 _metadata.Builder.AddInterfaceImplementation(handle, _metadata.GetTypeHandle(ifc));
             }
 
-            // If the type is an interface they may be no interface map.
+            // If the type is an interface there may be no interface map.
             // TODO: This isn't necessarily true for Default interface methods.
             if (type.IsInterface)
             {

--- a/test/TestSubject/MyClass.Methods.cs
+++ b/test/TestSubject/MyClass.Methods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 // This project defines a set of types that will be rewritten by the test cases to a new
@@ -12,6 +13,9 @@ namespace TestSubject
 {
     public partial class MyClass : IMyItf
     {
+        [DllImport("DOES_NOT_EXIST")]
+        public extern static int DontCall(int a);
+
         public void VoidMethod()
         {
         }


### PR DESCRIPTION
This was observed when attempting to serialize the `ComImport` attribute. Upon further investigation it was discovered that P/Invokes were also not supported so that has been added. Testing for the P/Invoke case is incomplete due to lack of stable binary to use. It would be possible to make a pure managed solution here if the [DNNE](https://github.com/AaronRobinsonMSFT/DNNE) library was leveraged to create native exports. However, that requires .NET 5+.