### PR TITLE
Add support for null attribute values

### DIFF
--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -66,10 +66,21 @@ namespace Lokad.ILPack
                     EncodeLiteral(subLitEnc.AddLiteral(), el);
                 }
             }
+            else if (arg.Value is null)
+            {
+                if (arg.ArgumentType.IsArray)
+                {
+                    litEnc.Scalar().NullArray();
+                }
+                else
+                {
+                    litEnc.Scalar().Constant(null);
+                }
+            }
             else
             {
                 // Check argument type supported (ie: simple scalar values)
-                PrimitiveTypeCodeFromSystemTypeCode(arg.Value.GetType());
+                PrimitiveTypeCodeFromSystemTypeCode(arg.Value?.GetType());
                 litEnc.Scalar().Constant(arg.Value);
             }
         }

--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -80,7 +80,7 @@ namespace Lokad.ILPack
             else
             {
                 // Check argument type supported (ie: simple scalar values)
-                PrimitiveTypeCodeFromSystemTypeCode(arg.Value?.GetType());
+                PrimitiveTypeCodeFromSystemTypeCode(arg.Value.GetType());
                 litEnc.Scalar().Constant(arg.Value);
             }
         }

--- a/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
@@ -62,7 +62,7 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
-        public async void AttributeNullStringValue()
+        public async void AttributeNullString()
         {
             Assert.Null(
                 await Invoke(
@@ -71,12 +71,22 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
-        public async void AttributeNullArrayValue()
+        public async void AttributeNullArray()
         {
             Assert.Null(
                 await Invoke(
                     $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeNullArrayTest\").GetCustomAttribute<MyArrayAttribute>();",
-                    "attr.Value"));
+                    "attr.Values"));
+        }
+
+        [Fact]
+        public async void AttributeNullArrayValue()
+        {
+            Assert.Equal(
+                new object[] { null },
+                await Invoke(
+                    $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeNullArrayValueTest\").GetCustomAttribute<MyArrayAttribute>();",
+                    "attr.Values"));
         }
     }
 }

--- a/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
@@ -60,5 +60,23 @@ namespace Lokad.ILPack.Tests
                 "attr.NamedArray"
                 ));
         }
+
+        [Fact]
+        public async void AttributeNullStringValue()
+        {
+            Assert.Null(
+                await Invoke(
+                    $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeNullStringTest\").GetCustomAttribute<MyStringAttribute>();",
+                    "attr.Value"));
+        }
+
+        [Fact]
+        public async void AttributeNullArrayValue()
+        {
+            Assert.Null(
+                await Invoke(
+                    $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeNullArrayTest\").GetCustomAttribute<MyArrayAttribute>();",
+                    "attr.Value"));
+        }
     }
 }

--- a/test/TestSubject/MyArrayAttribute.cs
+++ b/test/TestSubject/MyArrayAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TestSubject
+{
+    public class MyArrayAttribute : Attribute
+    {
+        public MyArrayAttribute(object[] value)
+        {
+            Value = value;
+        }
+
+        public object[] Value { get; }
+    }
+}

--- a/test/TestSubject/MyArrayAttribute.cs
+++ b/test/TestSubject/MyArrayAttribute.cs
@@ -4,11 +4,11 @@ namespace TestSubject
 {
     public class MyArrayAttribute : Attribute
     {
-        public MyArrayAttribute(object[] value)
+        public MyArrayAttribute(string[] values)
         {
-            Value = value;
+            Values = values;
         }
 
-        public object[] Value { get; }
+        public string[] Values { get; }
     }
 }

--- a/test/TestSubject/MyClass.Attributes.cs
+++ b/test/TestSubject/MyClass.Attributes.cs
@@ -36,5 +36,10 @@ namespace TestSubject
         public void AttributeNullArrayTest()
         {
         }
+
+        [MyArrayAttribute(new string[] { null })]
+        public void AttributeNullArrayValueTest()
+        {
+        }
     }
 }

--- a/test/TestSubject/MyClass.Attributes.cs
+++ b/test/TestSubject/MyClass.Attributes.cs
@@ -26,5 +26,15 @@ namespace TestSubject
             NamedArray = new int[] { 40, 50, 60 }
             )]
         public int AttributeOnProperty { get; set; }
+
+        [MyStringAttribute(null)]
+        public void AttributeNullStringTest()
+        {
+        }
+
+        [MyArrayAttribute(null)]
+        public void AttributeNullArrayTest()
+        {
+        }
     }
 }

--- a/test/TestSubject/MyStringAttribute.cs
+++ b/test/TestSubject/MyStringAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TestSubject
+{
+    public class MyStringAttribute : Attribute
+    {
+        public MyStringAttribute(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+    }
+}


### PR DESCRIPTION
I was facing an issue with attributes containing null values (passed as constructor parameters). It looked like it was not implemented at all because `NullReferenceException` was thrown at `EncodeLiteral()` due to `GetType()` being called on a null `Value`:
```
PrimitiveTypeCodeFromSystemTypeCode(arg.Value.GetType());
litEnc.Scalar().Constant(arg.Value);
```

Please review this fix
