### PR TITLE
Fixes #139 by replacing private corelib with netstandard reference

### DIFF
--- a/Lokad.ILPack.sln
+++ b/Lokad.ILPack.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lokad.ILPack", "src\Lokad.ILPack.csproj", "{7E7480A4-D10F-4489-B235-9FF58DD1B554}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lokad.ILPack.Tests", "test\Lokad.ILPack.Tests\Lokad.ILPack.Tests.csproj", "{8647DF26-57C1-465C-8E21-E44617D8EA60}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lokad.ILPack.Tests", "test\Lokad.ILPack.Tests\Lokad.ILPack.Tests.csproj", "{8647DF26-57C1-465C-8E21-E44617D8EA60}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSubject", "test\TestSubject\TestSubject.csproj", "{2B12E3D8-796A-4300-AE55-E151D0A129B8}"
 EndProject

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -19,11 +19,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="3.11.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0">
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="CS-Script" Version="3.29.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
@@ -16,11 +16,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting">
-      <Version>3.2.1</Version>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0">
     </PackageReference>
   </ItemGroup>
 
@@ -28,5 +28,8 @@
     <PackageReference Include="CS-Script" Version="3.29.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Microsoft.CodeAnalysis.Scripting" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Moving the whole block into a set of linq expressions, by targeting this magic string and replacing it with the netstandard assembly name, hopefully we can support .NET5 assemblies by not emitting assemblies that depend on "System.Private.CoreLib"