### PR TITLE
Added support for required custom modifiers

### DIFF
--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -92,6 +92,7 @@ namespace Lokad.ILPack.Metadata
                     {
                         foreach (var par in parameters)
                         {
+                            var p = parEnc.AddParameter();
                             if (par.ParameterType.IsByRef)
                             {
                                 var rts = par.GetRequiredCustomModifiers();

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -94,7 +94,16 @@ namespace Lokad.ILPack.Metadata
                         {
                             if (par.ParameterType.IsByRef)
                             {
-                                parEnc.AddParameter().Type(true).FromSystemType(par.ParameterType.GetElementType(), this);
+                                var rts = par.GetRequiredCustomModifiers();
+                                if (rts.Length > 0)
+                                {
+                                    var pcm = p.CustomModifiers();
+                                    foreach (var rt in rts)
+                                    {
+                                        pcm = pcm.AddModifier(ResolveTypeReference(rt), false);
+                                    }
+                                }
+                                p.Type(true).FromSystemType(par.ParameterType.GetElementType(), this);
                             }
                             else
                             {

--- a/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
@@ -88,5 +88,15 @@ namespace Lokad.ILPack.Tests
                 "var r = x.AnotherMethodWithDefaultParameterValues(2, \"\", \"\", 27);",
                 "r"));
         }
+
+        [Fact]
+
+        public async void VirtualMethodWithInModifier()
+        {
+            Assert.Equal("Hello", await Invoke(@"
+    var s = new StringSpan("" Hello "",1,5);
+    var r = (new TextPrinter()).Print(in s);
+", "r"));
+        }
     }
 }

--- a/test/TestSubject/TextPrinter.cs
+++ b/test/TestSubject/TextPrinter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestSubject
+{
+    public readonly struct StringSpan
+    {
+        public readonly string Source;
+        public readonly int Length;
+        public readonly int Offset;
+
+        public StringSpan(string source, int offset, int length)
+        {
+            this.Source = source;
+            this.Length = length;
+            this.Offset = offset;
+        }
+
+    }
+
+    public class TextPrinter
+    {
+
+        public virtual string Print(in StringSpan text)
+        {
+            return text.Source.Substring(text.Offset, text.Length);
+        }        
+
+    }
+}


### PR DESCRIPTION
Abstract and Virtual methods with `in` parameter modifier requires CustomModifiers in signature when calling the method. This is fixed. Test case..

Both Point and Shape are defined in different assembly.
```c#
public struct Point { 
    public readonly int X;
    public readonly int Y;
    public  Point(int x, int y) {
         this.X = x;
         this.Y = y;
    }
}


class Shape {

   // abstract method also requires CustomModifier
   public abstract void AbstractRender(in Point a);
   // virtual method also requires CustomModifier
   pubilc virtual void VirtualRender(in Point a);

}
```

