### PR TITLE
Cleaned up old and unsupported TFMs from the project files

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -260,7 +260,6 @@ namespace Lokad.ILPack
             }
         }
 
-#if NETSTANDARD || NET46
         internal static bool IsGenericMethodParameter(this Type type) => type.IsGenericParameter && type.DeclaringMethod != null;
 
         internal static bool IsConstructedGenericMethod(this MethodBase method) => method.IsGenericMethod && !method.IsGenericMethodDefinition;
@@ -315,15 +314,10 @@ namespace Lokad.ILPack
                 blob = (byte*)pointer;
 
                 return true;
-            } catch (Exception ex)
+            } catch
             {
                 return false;
             }
         }
-#else
-        internal static bool IsGenericMethodParameter( this Type type ) => type.IsGenericMethodParameter;
-
-        internal static bool IsConstructedGenericMethod( this MethodBase method ) => method.IsConstructedGenericMethod;
-#endif
     }
 }

--- a/src/Lokad.ILPack.csproj
+++ b/src/Lokad.ILPack.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>5</WarningLevel>
 
     <Company>Lokad</Company>
     <Copyright>Copyright © Lokad 2020</Copyright>
@@ -17,27 +20,20 @@
     <Authors>Lokad</Authors>
     <Description>A library for serializing dynamic assemblies under .NET Core.</Description>
     <PackageProjectUrl>https://github.com/Lokad/ILPack</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/Lokad/ILPack/master/lokad.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <Version>0.1.6</Version>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+  <ItemGroup>
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\LICENSE.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
+    <None Include="..\lokad.png" Pack="true" PackagePath="icon.png" />
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="\" />
   </ItemGroup>
+
 </Project>

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Sandbox/Sandbox.csproj
+++ b/test/Sandbox/Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/test/SandboxSubject/SandboxSubject.csproj
+++ b/test/SandboxSubject/SandboxSubject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/TestSubject/TestSubject.csproj
+++ b/test/TestSubject/TestSubject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
- Kept only .NET Standard 2.0 as a target platform for the NuGet package
- Replaced .NET Core 2.1 (out of support) with .NET Core 3.1 and .NET 5