### PR TITLE
Use proper offset for empty bodies

### DIFF
--- a/src/AssemblyGenerator.Constructors.cs
+++ b/src/AssemblyGenerator.Constructors.cs
@@ -30,15 +30,10 @@ namespace Lokad.ILPack
                     })));
             }
 
-            var bodyOffset = _metadata.ILBuilder.Count;
-
-            if (body != null)
-            {
-                var methodBodyWriter = new MethodBodyStreamWriter(_metadata);
-
-                // bodyOffset can be aligned during serialization. So, override the correct offset.
-                bodyOffset = methodBodyWriter.AddMethodBody(ctor, localVariablesSignature);
-            }
+            var bodyOffset = body != null
+                // bodyOffset can be aligned during serialization. So, use the correct offset.
+                ? new MethodBodyStreamWriter(_metadata).AddMethodBody(ctor, localVariablesSignature)
+                : -1;
 
             var parameters = CreateParameters(ctor.GetParameters());
 

--- a/test/Lokad.ILPack.Tests/RewriteTest.Delegates.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Delegates.cs
@@ -18,6 +18,15 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
+        public async void DelegateMyAction()
+        {
+            Assert.Equal(100, await Invoke(
+                $"var r = 0; x.DelegateMyAction(() => r = 100);",
+                "r"
+            ));
+        }
+
+        [Fact]
         public async void DelegateActionWithParam()
         {
             Assert.Equal(101, await Invoke(

--- a/test/TestSubject/MyClass.Delegates.cs
+++ b/test/TestSubject/MyClass.Delegates.cs
@@ -12,7 +12,14 @@ namespace TestSubject
 {
     public partial class MyClass
     {
+        public delegate void MyAction();
+
         public void DelegateAction(Action cb)
+        {
+            cb();
+        }
+
+        public void DelegateMyAction(MyAction cb)
         {
             cb();
         }


### PR DESCRIPTION
Constructors with an empty body should provide negative value as body offset (no RVA). (Resolves #121)