### PR TITLE
Changed approach for collecting the list of referenced assemblies

### DIFF
--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -33,9 +32,9 @@ namespace Lokad.ILPack
         private DebugDirectoryBuilder _debugDirectoryBuilder;
         private AssemblyMetadata _metadata;
 
-        private void Initialize(Assembly assembly, IEnumerable<Assembly> referencedDyncamicAsssemblies)
+        private void Initialize(Assembly assembly, IEnumerable<Assembly> referencedDynamicAssemblies)
         {
-            _metadata = new AssemblyMetadata(assembly, referencedDyncamicAsssemblies);
+            _metadata = new AssemblyMetadata(assembly, referencedDynamicAssemblies);
             _debugDirectoryBuilder = new DebugDirectoryBuilder();
         }
 

--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -700,5 +700,36 @@ namespace Lokad.ILPack.Tests
             Assert.True(IsTinyMethod(methodInfo));
             Assert.True(IsTinyMethod(constructorInfo));
         }
+
+        [Fact]
+        public void TestInterpolatedStrings()
+        {
+            var assemblyName = new AssemblyName { Name = "MyAssembly" };
+            var newAssembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var newModule = newAssembly.DefineDynamicModule("MyModule");
+
+            // Define a type with no namespace
+            var myType = newModule.DefineType("MyClass", TypeAttributes.Public);
+
+            // Define a method to just return a new instance of anonymous type.
+            var myMethod = myType.DefineMethod("MyMethod", MethodAttributes.Public, typeof(string), Type.EmptyTypes);
+            var generator = myMethod.GetILGenerator();
+            var builder = generator.DeclareLocal(typeof(System.Runtime.CompilerServices.DefaultInterpolatedStringHandler));
+            generator.Emit(OpCodes.Ldloca, builder.LocalIndex);
+            generator.Emit(OpCodes.Ldc_I4, 0);
+            generator.Emit(OpCodes.Ldc_I4, 0);
+
+            var DefaultInterpolatedStringHandlerConstructorInfo = builder.LocalType.GetConstructor(new[] { typeof(int), typeof(int) })!;
+            var ToStringAndClearInfo = builder.LocalType.GetMethod("ToStringAndClear", Type.EmptyTypes)!;
+
+            generator.Emit(OpCodes.Call, DefaultInterpolatedStringHandlerConstructorInfo);
+            generator.Emit(OpCodes.Ldloca, builder.LocalIndex);
+            generator.Emit(OpCodes.Call, ToStringAndClearInfo);
+            generator.Emit(OpCodes.Ret);
+
+            myType.CreateType();
+
+            SerializeAndVerifyAssembly(newAssembly, "InterpolatedStringsSerialization.dll");
+        }
     }
 }


### PR DESCRIPTION
- Replace `GroupBy` and `Select` with the `HashSet` and custom comparer for better readability and performance.
- Make the `netstandard` assembly adding conditional (allow users to manage dependencies manually).
- Make the `System.Private.CoreLib` assembly replacement optional (via the `AppContext` switch).

Fixes #152, fixes #23 and replacement for the PR #148