### PR TITLE
Pass proper entry point RVA into the `ManagedPEBuilder` constructor

### DIFF
--- a/src/AssemblyGenerator.cs
+++ b/src/AssemblyGenerator.cs
@@ -85,12 +85,6 @@ namespace Lokad.ILPack
         {
             Initialize(assembly, referencedDynamicAssembly);
 
-            if (_metadata.SourceAssembly.EntryPoint != null)
-            {
-                // See "<Module>" type definition below.
-                throw new NotSupportedException("Entry point is not supported.");
-            }
-
             var name = _metadata.SourceAssembly.GetName();
 
             var assemblyPublicKey = name.GetPublicKey();
@@ -103,14 +97,6 @@ namespace Lokad.ILPack
                 ConvertAssemblyHashAlgorithm(name.HashAlgorithm));
 
             // Add "<Module>" type definition *before* any type definition.
-            //
-            // TODO: [osman] methodList argument should be as following:
-            //
-            //   methodList: entryPoint.IsNil ? MetadataTokens.MethodDefinitionHandle(1) : entryPoint
-            //
-            // But, in order to work above code, we need to serialize
-            // entry point *without* serializing any type definition.
-            // This is not needed for libraries since they don't have any entry point.
             _metadata.Builder.AddTypeDefinition(
                 default,
                 default,

--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -751,6 +751,29 @@ namespace Lokad.ILPack.Tests
             var type = assembly.GetType("Type\\+");
             Assert.NotNull(type);
         }
+                
+        [Fact]
+        public void TestMoreSpecialCharacters()
+        {
+            /* SAVE */
+            var assemblyName = new AssemblyName { Name = "Assembly++" };
+
+            var newAssembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var newModule = newAssembly.DefineDynamicModule("Assembly++");
+
+            var myType = newModule.DefineType("A.B*C.D&E", TypeAttributes.Public);
+            myType.CreateType();
+            
+            var nested = myType.DefineNestedType("F", TypeAttributes.NestedPublic);
+            nested.CreateType();
+
+            SerializeAndVerifyAssembly(newAssembly, "Assembly++.dll");
+
+            /* LOAD */
+            Assembly assembly = LoadAssembly("Assembly++.dll");
+            Type type = assembly.GetType(@"A.B\*C.D\&E+F");
+            Assert.NotNull(type);
+        }
 
         [Fact]
         public void TestUnescape()
@@ -758,12 +781,13 @@ namespace Lokad.ILPack.Tests
             Assert.Equal(@"", AssemblyGenerator.Unescape(@""));
             Assert.Equal(@"x", AssemblyGenerator.Unescape(@"x"));
             Assert.Equal(@"\", AssemblyGenerator.Unescape(@"\"));
-            Assert.Equal(@"x", AssemblyGenerator.Unescape(@"\x"));
             Assert.Equal(@"\", AssemblyGenerator.Unescape(@"\\"));
             Assert.Equal(@"\\", AssemblyGenerator.Unescape(@"\\\"));
             Assert.Equal(@"\\", AssemblyGenerator.Unescape(@"\\\\"));
+
+            Assert.Equal(@"\x", AssemblyGenerator.Unescape(@"\x"));
             Assert.Equal(@"x\", AssemblyGenerator.Unescape(@"x\"));
-            Assert.Equal(@"\xx\\x\", AssemblyGenerator.Unescape(@"\\\xx\\\\\x\\"));
+            Assert.Equal(@"A.B*C.D&E+F", AssemblyGenerator.Unescape(@"A.B\*C.D\&E+F"));
         }
     }
 }


### PR DESCRIPTION
Fixes #37. Use a simple approach for entry point definition - it works fine for .NET 3.1 and later.

This PR also contains more unit tests for the name unescaping feature and changes for existing (incorrect) tests.