### PR TITLE
A lot of changes related to the generic types handling in body writer

### DIFF
--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -35,7 +35,7 @@ namespace Lokad.ILPack
                 var attrTypeHandle = _metadata.GetTypeHandle(attrType); // create type
 
                 // Get handle to the constructor
-                var ctorHandle = _metadata.GetConstructorHandle(attr.Constructor);
+                var ctorHandle = _metadata.GetConstructorHandle(attr.Constructor, false);
                 System.Diagnostics.Debug.Assert(!ctorHandle.IsNil);
 
                 // Encode the attribute values

--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -218,8 +218,8 @@ namespace Lokad.ILPack
                         // (This is the equivalent of .Override in msil)
                         _metadata.Builder.AddMethodImplementation(
                            (TypeDefinitionHandle)_metadata.GetTypeHandle(targetMethod.DeclaringType),
-                           _metadata.GetMethodHandle(targetMethod),
-                           _metadata.GetMethodHandle(ifcMethod));
+                           _metadata.GetMethodHandle(targetMethod, false),
+                           _metadata.GetMethodHandle(ifcMethod, false));
                     }
                 }
             }

--- a/src/IL/MethodBodyWriter.cs
+++ b/src/IL/MethodBodyWriter.cs
@@ -104,17 +104,17 @@ namespace Lokad.ILPack.IL
 
                             case ConstructorInfo constructorInfo:
                                 metadata.ILBuilder.WriteInt32(
-                                    MetadataTokens.GetToken(metadata.GetConstructorHandle(constructorInfo)));
+                                    MetadataTokens.GetToken(metadata.GetConstructorHandle(constructorInfo, true)));
                                 break;
 
                             case FieldInfo fieldInfo:
                                 metadata.ILBuilder.WriteInt32(
-                                    MetadataTokens.GetToken(metadata.GetFieldHandle(fieldInfo)));
+                                    MetadataTokens.GetToken(metadata.GetFieldHandle(fieldInfo, true)));
                                 break;
 
                             case MethodInfo methodInfo:
                                 metadata.ILBuilder.WriteInt32(
-                                    MetadataTokens.GetToken(metadata.GetMethodHandle(methodInfo)));
+                                    MetadataTokens.GetToken(metadata.GetMethodHandle(methodInfo, true)));
                                 break;
 
                             default:

--- a/src/Metadata/IAssemblyMetadata.cs
+++ b/src/Metadata/IAssemblyMetadata.cs
@@ -10,8 +10,8 @@ namespace Lokad.ILPack.Metadata
 
         UserStringHandle GetOrAddUserString(string value);
         EntityHandle GetTypeHandle(Type type);
-        EntityHandle GetFieldHandle(FieldInfo field);
-        EntityHandle GetConstructorHandle(ConstructorInfo ctor);
-        EntityHandle GetMethodHandle(MethodInfo method);
+        EntityHandle GetFieldHandle(FieldInfo field, Boolean inMethodBodyWritingContext);
+        EntityHandle GetConstructorHandle(ConstructorInfo ctor, Boolean inMethodBodyWritingContext);
+        EntityHandle GetMethodHandle(MethodInfo method, Boolean inMethodBodyWritingContext);
     }
 }

--- a/test/Lokad.ILPack.Tests/RewriteTest.ConstructedGenerics.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.ConstructedGenerics.cs
@@ -8,21 +8,39 @@ namespace Lokad.ILPack.Tests
     public partial class RewriteTest
     {
         [Fact]
-        public async void GenericInt()
+        public async void GenericStructInt()
         {
             Assert.Equal(5, await Invoke(
-                @"var r = x.GenericInt;",
+                @"var r = x.GenericStructInt;",
                 "r.Value"
                 ));
         }
 
         [Fact]
-        public async void GenericConstructedMethod()
+        public async void GenericStructConstructedMethod()
         {
             Assert.Equal("Hello Generic World!", await Invoke(
-                @"var r = x.GenericConstructedMethod(""Hello Generic World!"");",
+                @"var r = x.GenericStructConstructedMethod(""Hello Generic World!"");",
                 "r.Value"
                 ));
+        }
+
+        [Fact]
+        public async void GenericClassInt()
+        {
+            Assert.Equal(5, await Invoke(
+                @"var r = x.GenericClassInt;",
+                "r.Value"
+            ));
+        }
+
+        [Fact]
+        public async void GenericClassConstructedMethod()
+        {
+            Assert.Equal("Hello Generic World!", await Invoke(
+                @"var r = x.GenericClassConstructedMethod(""Hello Generic World!"");",
+                "r.Value"
+            ));
         }
     }
 }

--- a/test/Lokad.ILPack.Tests/RewriteTest.Properties.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Properties.cs
@@ -28,13 +28,12 @@ namespace Lokad.ILPack.Tests
                 "x.ReadWriteProperty"));
         }
 
-        // TODO: See https://github.com/Lokad/ILPack/issues/127
-        //[Fact]
-        //public async void WrappedSingleton()
-        //{
-        //    Assert.Equal(default(string), await Invoke(
-        //        "",
-        //        "x.WrappedSingleton"));
-        //}
+        [Fact]
+        public async void WrappedSingleton()
+        {
+            Assert.Equal(default(string), await Invoke(
+                "",
+                "x.WrappedSingleton"));
+        }
     }
 }

--- a/test/Lokad.ILPack.Tests/dump.bat
+++ b/test/Lokad.ILPack.Tests/dump.bat
@@ -1,4 +1,4 @@
-ildasm /bytes bin\Debug\netcoreapp2.1\TestSubject.dll > il.original.txt
-ildasm /bytes bin\Debug\netcoreapp2.1\cloned\ClonedTestSubject.dll > il.clone.txt
-mddumper bin\Debug\netcoreapp2.1\TestSubject.dll > md.original.txt
-mddumper bin\Debug\netcoreapp2.1\cloned\ClonedTestSubject.dll > md.clone.txt
+ildasm /bytes bin\Debug\net6.0\TestSubject.dll > il.original.txt
+ildasm /bytes bin\Debug\net6.0\cloned\ClonedTestSubject.dll > il.clone.txt
+mddumper bin\Debug\net6.0\TestSubject.dll > md.original.txt
+mddumper bin\Debug\net6.0\cloned\ClonedTestSubject.dll > md.clone.txt

--- a/test/Sandbox/Sandbox.csproj
+++ b/test/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 	<OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/Sandbox/asm.bat
+++ b/test/Sandbox/asm.bat
@@ -1,1 +1,1 @@
-ilasm /dll il.clone.txt /output=bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll
+ilasm /dll il.clone.txt /output=bin\Debug\net6.0\cloned\ClonedSandboxSubject.dll

--- a/test/Sandbox/dump.bat
+++ b/test/Sandbox/dump.bat
@@ -1,4 +1,4 @@
-ildasm /bytes bin\Debug\netcoreapp2.1\SandboxSubject.dll > il.original.txt
-ildasm /bytes bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll > il.clone.txt
-mddumper bin\Debug\netcoreapp2.1\SandboxSubject.dll > md.original.txt
-mddumper bin\Debug\netcoreapp2.1\cloned\ClonedSandboxSubject.dll > md.clone.txt
+ildasm /bytes bin\Debug\net6.0\SandboxSubject.dll > il.original.txt
+ildasm /bytes bin\Debug\net6.0\cloned\ClonedSandboxSubject.dll > il.clone.txt
+mddumper bin\Debug\net6.0\SandboxSubject.dll > md.original.txt
+mddumper bin\Debug\net6.0\cloned\ClonedSandboxSubject.dll > md.clone.txt

--- a/test/SandboxSubject/SandboxSubject.csproj
+++ b/test/SandboxSubject/SandboxSubject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/TestSubject/MyClass.ConstructedGenerics.cs
+++ b/test/TestSubject/MyClass.ConstructedGenerics.cs
@@ -4,18 +4,41 @@ using System.Text;
 
 namespace TestSubject
 {
-    public struct GenericClass<T>
+    public struct GenericStruct<T>
     {
         public T Value;
     }
 
+    public class GenericClassBase<TBase>
+    {
+        public TBase BaseValue;
+
+        public GenericClassBase() { }
+    }
+
+    public class GenericClass<T> : GenericClassBase<T>
+    {
+        public T Value;
+
+        public GenericClass() { }
+    }
+
     public partial class MyClass
     {
-        private GenericClass<int> _genericInt = new GenericClass<int>() { Value = 5 };
+        private GenericStruct<int> _genericStructInt = new GenericStruct<int>() { Value = 5 };
 
-        public GenericClass<int> GenericInt => _genericInt;
+        public GenericStruct<int> GenericStructInt => _genericStructInt;
 
-        public GenericClass<T> GenericConstructedMethod<T>(T value)
+        public GenericStruct<T> GenericStructConstructedMethod<T>(T value)
+        {
+            return new GenericStruct<T>() { Value = value };
+        }
+
+        private GenericClass<int> _genericClassInt = new GenericClass<int>() { Value = 5 };
+
+        public GenericClass<int> GenericClassInt => _genericClassInt;
+
+        public GenericClass<T> GenericClassConstructedMethod<T>(T value)
         {
             return new GenericClass<T>() { Value = value };
         }

--- a/test/TestSubject/MyClass.Properties.cs
+++ b/test/TestSubject/MyClass.Properties.cs
@@ -33,13 +33,12 @@ namespace TestSubject
             set;
         }
 
-        // TODO: See https://github.com/Lokad/ILPack/issues/127
-        //public string WrappedSingleton
-        //{
-        //    get
-        //    {
-        //        return MySingleton<string>.Instance;
-        //    }
-        //}
+        public string WrappedSingleton
+        {
+            get
+            {
+                return MySingleton<string>.Instance;
+            }
+        }
     }
 }

--- a/test/TestSubject/MySingleton.cs
+++ b/test/TestSubject/MySingleton.cs
@@ -1,13 +1,12 @@
 ﻿namespace TestSubject
 {
-    // TODO: See https://github.com/Lokad/ILPack/issues/127
-    //public static class MySingleton<T>
-    //{
-    //    public static readonly T Instance;
+    public static class MySingleton<T>
+    {
+        public static readonly T Instance;
 
-    //    static MySingleton()
-    //    {
-    //        Instance = default;
-    //    }
-    //}
+        static MySingleton()
+        {
+            Instance = default;
+        }
+    }
 }


### PR DESCRIPTION
- Removed all 'partial' workarounds for generic type members references in method bodies
- Implement proper metadata tokens generation for "fully constructed" generic types
- Use partially constructed type specifications for generic members' usage

All these changes fix #127 and potentially many other generics-related issues.