### PR TITLE
Proper fix for the `NullReferenceException` in the `AssemblyGenerator` class.

### DIFF
--- a/src/AssemblyGenerator.Types.cs
+++ b/src/AssemblyGenerator.Types.cs
@@ -212,7 +212,7 @@ namespace Lokad.ILPack
 
                     // Declare a method override either when the interface implementation or
                     // the interface method implementation is declared by the type.
-                    if (implementedByType || targetMethod?.DeclaringType == type)
+                    if (targetMethod != null && (implementedByType || targetMethod.DeclaringType == type))
                     {
                         // Mark the target method as implementing the interface method.
                         // (This is the equivalent of .Override in msil)

--- a/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
+++ b/test/Lokad.ILPack.Tests/AssemblyGeneratorTest.cs
@@ -733,6 +733,30 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
+        public void TestBuildNullTargetMethod()
+        { 
+            var assemblyName = new AssemblyName("MissingAbstractTestExample");
+
+            var newAssembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var newModule = newAssembly.DefineDynamicModule("MissingAbstractTestExample");
+
+            var interfaceA = newModule.DefineType("IA", 
+                TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+            interfaceA.DefineMethod("ma", 
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract,
+                typeof(int), Array.Empty<Type>());
+            interfaceA.CreateType();
+
+            var classA = newModule.DefineType("CA",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract,
+                null, new Type[] { interfaceA });
+            classA.CreateType();
+
+            SerializeAndVerifyAssembly(newAssembly, "MissingAbstractTestExample.dll");          
+
+        }
+
+        [Fact]
         public void TestSpecialCharacters()
         {
             /* SAVE */


### PR DESCRIPTION
Interface mapping processing logic was rewritten for preventing null reference exceptions.
Fixes #164 - with unit test and proper fix for cases with interface declared but not implemented.