### PR TITLE
Correctly process inline signatures

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -319,5 +319,16 @@ namespace Lokad.ILPack
                 return false;
             }
         }
+
+        internal static void AddCustomModifiers(this IAssemblyMetadata metadata, CustomModifiersEncoder cme, 
+            IEnumerable<Type> requiredModifiers, IEnumerable<Type> optionalModifiers) => cme
+            .AddCustomModifiers(metadata, requiredModifiers, false)
+            .AddCustomModifiers(metadata, optionalModifiers, true);
+
+        private static CustomModifiersEncoder AddCustomModifiers(
+            this CustomModifiersEncoder cme, IAssemblyMetadata metadata, IEnumerable<Type> modifiers, bool isOptional) =>
+            modifiers.Aggregate(cme, (current, modifier) =>
+                current.AddModifier(metadata.GetTypeHandle(modifier), isOptional));
+
     }
 }

--- a/src/IL/MethodBodyReader.cs
+++ b/src/IL/MethodBodyReader.cs
@@ -118,7 +118,7 @@ namespace Lokad.ILPack.IL
                     break;
 
                 case OperandType.InlineSig:
-                    instruction.Operand = _module.ResolveSignature(_il.ReadInt32());
+                    instruction.Operand = SignatureInfo.Create(_il.ReadInt32(), _typeArguments, _methodArguments, _module);
                     break;
 
                 case OperandType.InlineString:

--- a/src/IL/MethodBodyWriter.cs
+++ b/src/IL/MethodBodyWriter.cs
@@ -84,7 +84,8 @@ namespace Lokad.ILPack.IL
                         break;
 
                     case OperandType.InlineSig:
-                        metadata.ILBuilder.WriteBytes((byte[]) il[i].Operand);
+                        metadata.ILBuilder.WriteInt32(
+                            MetadataTokens.GetToken(metadata.GetSignatureHandle((SignatureInfo)il[i].Operand)));
                         break;
 
                     case OperandType.InlineString:

--- a/src/IL/SignatureInfo.cs
+++ b/src/IL/SignatureInfo.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using Lokad.ILPack.Metadata;
+
+namespace Lokad.ILPack.IL
+{
+    public sealed class SignatureInfo
+    {
+        private readonly struct TypeWithModifiers
+        {
+            private readonly LinkedList<Type> _optionalModifiers;
+
+            private readonly LinkedList<Type> _requiredModifiers;
+
+            private readonly Type _type;
+
+            private TypeWithModifiers(
+                Type type)
+                : this(
+                    null,
+                    null,
+                    type)
+            {
+            }
+
+            private TypeWithModifiers(
+                TypeWithModifiers prototype,
+                Type type)
+                : this(
+                    prototype._optionalModifiers,
+                    prototype._requiredModifiers,
+                    type)
+            {
+            }
+
+            private TypeWithModifiers(
+                LinkedList<Type> optionalModifiers,
+                LinkedList<Type> requiredModifiers,
+                Type type)
+            {
+                _optionalModifiers = optionalModifiers;
+                _requiredModifiers = requiredModifiers;
+                _type = type;
+            }
+
+            public Type Type => _type?.GetElementType() ?? _type;
+
+            public bool IsByRef => _type.IsByRef;
+            public IEnumerable<Type> RequiredModifiers =>
+                _requiredModifiers ?? Enumerable.Empty<Type>();
+
+            public IEnumerable<Type> OptionalModifiers =>
+                _optionalModifiers ?? Enumerable.Empty<Type>();
+
+            public bool HasModifiers =>
+                _optionalModifiers != null || _requiredModifiers != null;
+
+            public static implicit operator TypeWithModifiers(
+                Type type) => new TypeWithModifiers(type);
+
+            public TypeWithModifiers MakeArrayType() =>
+                new TypeWithModifiers(this, _type.MakeArrayType());
+
+            public TypeWithModifiers MakeByRefType() =>
+                new TypeWithModifiers(this, _type.MakeByRefType());
+
+            public TypeWithModifiers MakePointerType() =>
+                new TypeWithModifiers(this, _type.MakePointerType());
+
+            public TypeWithModifiers MakeArrayType(int rank) =>
+                new TypeWithModifiers(this, _type.MakeArrayType(rank));
+
+            public TypeWithModifiers MakeGenericType(
+                Type[] typeArguments) =>
+                new TypeWithModifiers(this, _type.MakeGenericType(typeArguments));
+
+            public TypeWithModifiers AddModifier(
+                Type modifier,
+                Boolean isOptional) =>
+                isOptional
+                    ? new TypeWithModifiers(
+                        AddLastSafe(_optionalModifiers, modifier), _requiredModifiers, _type)
+                    : new TypeWithModifiers(
+                        _optionalModifiers, AddLastSafe(_requiredModifiers, modifier), _type);
+
+            private static LinkedList<Type> AddLastSafe(LinkedList<Type> list, Type item)
+            {
+                list ??= new LinkedList<Type>();
+                list.AddLast(item);
+                return list;
+            }
+        }
+
+        private sealed class SignatureReader
+        {
+            private readonly Type[] _methodArguments;
+
+            private readonly Type[] _typeArguments;
+
+            private readonly Module _module;
+
+            private BlobReader _reader;
+
+            public SignatureReader(
+                Module module,
+                byte[] signature,
+                Type [] typeArguments,
+                Type [] methodArguments)
+            {
+                _methodArguments = methodArguments;
+                _typeArguments = typeArguments;
+                _reader = GetReader(signature);
+                _module = module;
+            }
+
+            public SignatureCallingConvention ReadCallingConvention() =>
+                _reader.ReadSignatureHeader().CallingConvention;
+
+            public IEnumerable<TypeWithModifiers> ReadReturnTypeAndParameters() =>
+                ReadTypes(_reader.ReadCompressedInteger() + 1);
+
+            private static unsafe BlobReader GetReader(
+                byte[] signature)
+            {
+                fixed (byte* pSignature = signature)
+                {
+                    return new BlobReader(pSignature, signature.Length);
+                }
+            }
+
+            private TypeWithModifiers ReadType() =>
+                // ReSharper disable once SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
+                _reader.ReadSignatureTypeCode() switch
+                {
+                    SignatureTypeCode.Array => ReadType().MakeArrayType(ReadArrayRank()),
+
+                    SignatureTypeCode.ByReference => ReadType().MakeByRefType(),
+
+                    SignatureTypeCode.Pointer => ReadType().MakePointerType(),
+
+                    SignatureTypeCode.SZArray => ReadType().MakeArrayType(),
+
+                    SignatureTypeCode.TypeHandle => ReadTypeFromToken(),
+
+                    SignatureTypeCode.GenericMethodParameter =>
+                        _methodArguments[_reader.ReadCompressedInteger()],
+
+                    SignatureTypeCode.GenericTypeParameter =>
+                        _typeArguments[_reader.ReadCompressedInteger()],
+
+                    SignatureTypeCode.GenericTypeInstance =>
+                        ReadType().MakeGenericType(ReadTypesArray()),
+
+                    SignatureTypeCode.UIntPtr => typeof(UIntPtr),
+                    SignatureTypeCode.IntPtr => typeof(IntPtr),
+
+                    SignatureTypeCode.UInt64 => typeof(ulong),
+                    SignatureTypeCode.UInt32 => typeof(uint),
+                    SignatureTypeCode.UInt16 => typeof(ushort),
+                    SignatureTypeCode.Byte => typeof(byte),
+
+                    SignatureTypeCode.Int64 => typeof(long),
+                    SignatureTypeCode.Int32 => typeof(int),
+                    SignatureTypeCode.Int16 => typeof(short),
+                    SignatureTypeCode.SByte => typeof(sbyte),
+
+                    SignatureTypeCode.Boolean => typeof(bool),
+                    SignatureTypeCode.String => typeof(string),
+                    SignatureTypeCode.Object => typeof(object),
+                    SignatureTypeCode.Char => typeof(char),
+
+                    SignatureTypeCode.Double => typeof(double),
+                    SignatureTypeCode.Single => typeof(float),
+
+                    SignatureTypeCode.Void => null,
+
+                    SignatureTypeCode.OptionalModifier => ReadTypeWithModifier(
+                        ReadTypeFromToken(), true, ReadType()),
+                    SignatureTypeCode.RequiredModifier => ReadTypeWithModifier(
+                        ReadTypeFromToken(), false, ReadType()),
+
+                    //SignatureTypeCode.FunctionPointer => null, // TODO: olegra - read SignatureInfo recursively
+
+                    _ => throw new InvalidOperationException(
+                        $"This type code is not supported yet.")
+                };
+
+            private Type[] ReadTypesArray() =>
+                ReadTypes(_reader.ReadCompressedInteger()).Select(_ => _.Type).ToArray();
+
+            private IEnumerable<TypeWithModifiers> ReadTypes(
+                int count)
+            {
+                for (var index = 0; index < count; ++index)
+                {
+                    yield return ReadType();
+                }
+            }
+
+            private Type ReadTypeFromToken() =>
+                _module.ResolveType(
+                    MetadataTokens.GetToken(_reader.ReadTypeHandle()));
+
+            private TypeWithModifiers ReadTypeWithModifier(
+                Type modifier,
+                bool isOptional,
+                TypeWithModifiers type) =>
+                type.AddModifier(modifier, isOptional);
+
+            private int ReadArrayRank()
+            {
+                var rank = _reader.ReadCompressedInteger();
+                for (var index = rank + 2; index > 0; --index)
+                {
+                    _reader.ReadCompressedInteger();
+                }
+                return rank;
+            }
+        }
+
+        private readonly SignatureCallingConvention _signatureCallingConvention;
+
+        private readonly List<TypeWithModifiers> _returnTypeAndParameters;
+
+        private SignatureInfo(
+            SignatureCallingConvention signatureCallingConvention,
+            List<TypeWithModifiers> returnTypeAndParameters)
+        {
+            _signatureCallingConvention = signatureCallingConvention;
+            _returnTypeAndParameters = returnTypeAndParameters;
+        }
+
+        public BlobBuilder GetBlobBuilder(
+            IAssemblyMetadata metadata)
+        {
+            var methodSignatureEncoder = new BlobEncoder(new BlobBuilder())
+                .MethodSignature(_signatureCallingConvention);
+
+            // Add return type and parameters
+            methodSignatureEncoder.Parameters(
+                _returnTypeAndParameters.Count - 1, // First type is return type
+                returnTypeEncoder =>
+                {
+                    var returnType = _returnTypeAndParameters[0].Type;
+                    if (returnType is null)
+                    {
+                        returnTypeEncoder.Void();
+                    }
+                    else
+                    {
+                        returnTypeEncoder.Type().FromSystemType(returnType, metadata);
+                    }
+                },
+                parametersEncoder =>
+                {
+                    // Skip the first element in list - it's a return type
+                    for (var index = 1; index < _returnTypeAndParameters.Count; index++)
+                    {
+                        var parameter = _returnTypeAndParameters[index];
+                        var parameterTypeEncoder = parametersEncoder.AddParameter();
+
+                        if (parameter.HasModifiers)
+                        {
+                            metadata.AddCustomModifiers(parameterTypeEncoder.CustomModifiers(),
+                                parameter.RequiredModifiers, parameter.OptionalModifiers);
+                        }
+
+                        parameterTypeEncoder.Type(parameter.IsByRef).FromSystemType(parameter.Type, metadata);
+                    }
+                }
+            );
+
+            return methodSignatureEncoder.Builder;
+        }
+
+        public static SignatureInfo Create(
+            int metadataToken,
+            Type [] typeArguments,
+            Type [] methodArguments,
+            Module module)
+        {
+            var reader = new SignatureReader(
+                module, module.ResolveSignature(metadataToken),
+                typeArguments, methodArguments);
+
+            var callingConvention = reader.ReadCallingConvention();
+            var returnTypeAndParameters = reader.ReadReturnTypeAndParameters().ToList();
+
+            return new SignatureInfo(callingConvention, returnTypeAndParameters);
+        }
+    }
+}

--- a/src/IL/SignatureInfo.cs
+++ b/src/IL/SignatureInfo.cs
@@ -183,7 +183,7 @@ namespace Lokad.ILPack.IL
                     SignatureTypeCode.RequiredModifier => ReadTypeWithModifier(
                         ReadTypeFromToken(), false, ReadType()),
 
-                    //SignatureTypeCode.FunctionPointer => null, // TODO: olegra - read SignatureInfo recursively
+                    //SignatureTypeCode.FunctionPointer => null, // TODO: read SignatureInfo recursively
 
                     _ => throw new InvalidOperationException(
                         $"This type code is not supported yet.")

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using Lokad.ILPack.IL;
 
 namespace Lokad.ILPack.Metadata
 {
@@ -25,6 +27,9 @@ namespace Lokad.ILPack.Metadata
             throw new ArgumentException($"Method cannot be found: {MetadataHelper.GetFriendlyName(method)}",
                 nameof(method));
         }
+
+        public EntityHandle GetSignatureHandle(SignatureInfo signature) =>
+            Builder.AddStandaloneSignature(GetOrAddBlob(signature.GetBlobBuilder(this)));
 
         public BlobHandle GetMethodOrConstructorSignature(MethodBase methodBase)
         {
@@ -81,9 +86,9 @@ namespace Lokad.ILPack.Metadata
                     parameters.Length,
                     (retEnc) =>
                     {
-                        if (methodBase is MethodInfo)
+                        if (methodBase is MethodInfo methodInfo)
                         {
-                            retEnc.FromSystemType(((MethodInfo)methodBase).ReturnType, this);
+                            retEnc.FromSystemType(methodInfo.ReturnType, this);
                         }
                         else
                         {
@@ -104,7 +109,7 @@ namespace Lokad.ILPack.Metadata
                             }
                             else
                             {
-                                parEnc.AddParameter().Type(false).FromSystemType(par.ParameterType, this);
+                                p.Type(false).FromSystemType(par.ParameterType, this);
                             }
                         }
                     }

--- a/src/Metadata/AssemblyMetadata.Methods.cs
+++ b/src/Metadata/AssemblyMetadata.Methods.cs
@@ -62,7 +62,7 @@ namespace Lokad.ILPack.Metadata
                 // method with the same token.
                 //
                 // TODO: What about generic method definitions in a generic type???
-                System.Diagnostics.Debug.Assert(!methodBase.IsGenericMethod);
+                //System.Diagnostics.Debug.Assert(!methodBase.IsGenericMethod);
 
                 var definition = methodBase.DeclaringType.GetGenericTypeDefinition();
                 if (methodBase is MethodInfo)

--- a/src/Metadata/AssemblyMetadata.cs
+++ b/src/Metadata/AssemblyMetadata.cs
@@ -133,24 +133,13 @@ namespace Lokad.ILPack.Metadata
         
         private SignatureTypeEncoder AddCustomModifiers(SignatureTypeEncoder encoder, FieldInfo info)
         {
-            AddCustomModifiers(encoder.CustomModifiers(),
+            this.AddCustomModifiers(encoder.CustomModifiers(),
                 info.GetRequiredCustomModifiers(), info.GetOptionalCustomModifiers());
             return encoder;
         }
         
         private void AddCustomModifiers(ParameterTypeEncoder encoder, ParameterInfo info) =>
-            AddCustomModifiers(encoder.CustomModifiers(),
+            this.AddCustomModifiers(encoder.CustomModifiers(),
                 info.GetRequiredCustomModifiers(), info.GetOptionalCustomModifiers());
-
-        private void AddCustomModifiers(CustomModifiersEncoder cme,
-            IEnumerable<Type> requiredModifiers, IEnumerable<Type> optionalModifiers) =>
-            AddCustomModifiers(
-                AddCustomModifiers(cme, requiredModifiers, false),
-                optionalModifiers, true);
-
-        private CustomModifiersEncoder AddCustomModifiers(
-            CustomModifiersEncoder cme, IEnumerable<Type> modifiers, bool isOptional) =>
-            modifiers.Aggregate(cme, (current, modifier) =>
-                current.AddModifier(ResolveTypeReference(modifier), isOptional));
     }
 }

--- a/src/Metadata/IAssemblyMetadata.cs
+++ b/src/Metadata/IAssemblyMetadata.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Metadata;
+using Lokad.ILPack.IL;
 
 namespace Lokad.ILPack.Metadata
 {
@@ -13,5 +14,6 @@ namespace Lokad.ILPack.Metadata
         EntityHandle GetFieldHandle(FieldInfo field, Boolean inMethodBodyWritingContext);
         EntityHandle GetConstructorHandle(ConstructorInfo ctor, Boolean inMethodBodyWritingContext);
         EntityHandle GetMethodHandle(MethodInfo method, Boolean inMethodBodyWritingContext);
+        EntityHandle GetSignatureHandle(SignatureInfo signature);
     }
 }

--- a/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
+++ b/test/Lokad.ILPack.Tests/Lokad.ILPack.Tests.csproj
@@ -7,6 +7,7 @@
     <WarningLevel>5</WarningLevel>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Lokad.ILPack.snk</AssemblyOriginatorKeyFile>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Methods.cs
@@ -97,5 +97,23 @@ namespace Lokad.ILPack.Tests
     var r = new MyClassWithInModifier().Print(in s);
 ", "r"));
         }
+
+        [Fact]
+        public async void FunctionPointerWithGenericsCallback()
+        {
+            Assert.Equal(42, await Invoke(@"var r = x.MethodWithGenericCallback();", "r"));
+        }
+
+        [Fact]
+        public async void FunctionPointerWithCallback()
+        {
+            Assert.Equal((byte)42, await Invoke(@"var r = x.MethodWithSimpleCallback();", "r"));
+        }
+
+        [Fact]
+        public async void FunctionPointerWithModifiersCallback()
+        {
+            Assert.Equal("Hello", await Invoke(@"var r = x.MethodWithModifiersCallback();", "r"));
+        }
     }
 }

--- a/test/TestSubject/MyClass.Methods.cs
+++ b/test/TestSubject/MyClass.Methods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -83,6 +84,26 @@ namespace TestSubject
         public unsafe object call_methA() {
             byte* ptr = (byte*)0x123;
             return methA((byte*)ptr, (void*)ptr);
+        }
+
+        public byte MethodWithSimpleCallback()
+        {
+            return new MyUnsafe<int>().MethodWithSimpleCallback();
+        }
+
+        public string MethodWithModifiersCallback()
+        {
+            return new MyUnsafe<object>().MethodWithModifiersCallback();
+        }
+
+        public unsafe int MethodWithGenericCallback()
+        {
+            return new MyUnsafe<string>().MethodWithGenericCallback<int>(&GenericCallback);
+        }
+
+        private static int GenericCallback(Dictionary<int, string> input)
+        {
+            return 42;
         }
     }
 

--- a/test/TestSubject/MyUnsafe.cs
+++ b/test/TestSubject/MyUnsafe.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TestSubject
+{
+    internal unsafe class MyUnsafe<T>
+    {
+        public byte MethodWithSimpleCallback()
+        {
+            return MethodWithSimpleCallback(&SimpleCallback);
+        }
+
+        public string MethodWithModifiersCallback()
+        {
+            return MethodWithModifiersCallback(&ModifiersCallback);
+        }
+
+        public U MethodWithGenericCallback<U>(delegate*<Dictionary<U, T>, U> f)
+        {
+            return f(default);
+        }
+
+        private string MethodWithModifiersCallback(delegate*<in short[], ref byte[,], string> f)
+        {
+            var b = new byte[1,1];
+            return f(Array.Empty<short>(), ref b);
+        }
+
+        private byte MethodWithSimpleCallback(delegate*<int*, bool, object, IntPtr, byte> f)
+        {
+            return f(null, true, null, IntPtr.Zero);
+        }
+
+        private static string ModifiersCallback(in short[] x, ref byte[,] y)
+        {
+            return "Hello";
+        }
+
+        private static byte SimpleCallback(int* a, bool b, object c, IntPtr d)
+        {
+            return 42;
+        }
+    }
+}

--- a/test/TestSubject/TestSubject.csproj
+++ b/test/TestSubject/TestSubject.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Lokad.ILPack.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Inline signatures used by the `calli` MSIL instruction are part of a new high-performance low-level unsafe platform interop (function pointers in `delegate*` format). The current implementation handles most of the practical use cases except the single one: function pointers as arguments of function pointers. I'll open a separate issue for this use case (very rare). This PR completely covers and fixes #106.