### PR TITLE
Module attributes should be processed after types definitions.

### DIFF
--- a/src/AssemblyGenerator.Modules.cs
+++ b/src/AssemblyGenerator.Modules.cs
@@ -19,10 +19,10 @@ namespace Lokad.ILPack
 
                 var genericParams = new List<DelayedWrite>();
 
-                CreateCustomAttributes(moduleHandle, module.GetCustomAttributesData());
                 CreateFields(module.GetFields());
                 CreateTypes(module.GetTypes(), genericParams);
                 CreateMethods(module.GetMethods(AllMethods), genericParams);
+                CreateCustomAttributes(moduleHandle, module.GetCustomAttributesData());
 
                 // Delaying those writes, because generic parameters must be sorted first.
                 foreach (var dw in genericParams.OrderBy(tu => tu.Index))


### PR DESCRIPTION
Fixed problem that can be easily reproduced in the .NET SDK 7.0 - module can have attributes defined in the module itself.