### PR TITLE
Fixes regarding external assembly references which cannot be resolved

### DIFF
--- a/src/AssemblyGenerator.Attributes.cs
+++ b/src/AssemblyGenerator.Attributes.cs
@@ -55,7 +55,7 @@ namespace Lokad.ILPack
             if (arg.Value is Type type)
             {
                 // Type reference
-                litEnc.Scalar().SystemType(type.FullName);
+                litEnc.Scalar().SystemType(type.AssemblyQualifiedName);
             }
             else if (arg.Value is ReadOnlyCollection<CustomAttributeTypedArgument> array)
             {

--- a/src/Metadata/AssemblyMetadata.Types.cs
+++ b/src/Metadata/AssemblyMetadata.Types.cs
@@ -24,7 +24,7 @@ namespace Lokad.ILPack.Metadata
 
             // todo, also maybe in Module, ModuleRef, AssemblyRef and TypeRef
             // ECMA-335 page 273-274
-            return type.Assembly != SourceAssembly;
+            return !SourceAssembly.FullName.Equals(type.Assembly.FullName);
         }
 
         private EntityHandle ResolveTypeReference(Type type)


### PR DESCRIPTION
When saving an assemblybuilder to file I had two issues.
First one was a reference which could not be found when a type of a references assembly was passed as a parameter of an customattribute.
Second one that I had was that the IsReferencedType method was always returning false. 
Therefore I got an exception that the referenced assembly (the one that was being saved) could not be found.