### PR TITLE
Support attributes with object and object[] typed parameters

### DIFF
--- a/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
+++ b/test/Lokad.ILPack.Tests/RewriteTest.Attributes.cs
@@ -62,6 +62,15 @@ namespace Lokad.ILPack.Tests
         }
 
         [Fact]
+        public async void AttributeNamedObjectValues()
+        {
+            Assert.Equal(new object[] { 1d, 2 }, await Invoke(
+                $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeArrayTest\").GetCustomAttribute<MyAttribute>();",
+                "attr.NamedObject"
+            ));
+        }
+
+        [Fact]
         public async void AttributeNullString()
         {
             Assert.Null(
@@ -86,6 +95,16 @@ namespace Lokad.ILPack.Tests
                 new object[] { null },
                 await Invoke(
                     $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeNullArrayValueTest\").GetCustomAttribute<MyArrayAttribute>();",
+                    "attr.Values"));
+        }
+
+        [Fact]
+        public async void AttributeObjectArrayValue()
+        {
+            Assert.Equal(
+                new object[] { 1, 2.3f, "string", new [] { 4 } },
+                await Invoke(
+                    $"var attr = typeof({_namespaceName}.MyClass).GetMethod(\"AttributeObjectArrayValueTest\").GetCustomAttribute<MyObjectArrayAttribute>();",
                     "attr.Values"));
         }
     }

--- a/test/TestSubject/MyAttribute.cs
+++ b/test/TestSubject/MyAttribute.cs
@@ -14,5 +14,7 @@ namespace TestSubject
         public string Named { get; set; }
 
         public int[] NamedArray { get; set; }
+        
+        public object NamedObject { get; set; }
     }   
 }

--- a/test/TestSubject/MyClass.Attributes.cs
+++ b/test/TestSubject/MyClass.Attributes.cs
@@ -14,7 +14,8 @@ namespace TestSubject
         [MyAttribute(
             10, 20, 30, 
             Named = "ILPack", 
-            NamedArray = new int[] { 40, 50, 60 } 
+            NamedArray = new int[] { 40, 50, 60 },
+            NamedObject = new object[] { 1d, 2 }
             )]
         public void AttributeArrayTest()
         {
@@ -39,6 +40,11 @@ namespace TestSubject
 
         [MyArrayAttribute(new string[] { null })]
         public void AttributeNullArrayValueTest()
+        {
+        }
+
+        [MyObjectArrayAttribute(new object[] { 1, 2.3f, "string", new [] { 4 } })]
+        public void AttributeObjectArrayValueTest()
         {
         }
     }

--- a/test/TestSubject/MyObjectArrayAttribute.cs
+++ b/test/TestSubject/MyObjectArrayAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TestSubject;
+
+public class MyObjectArrayAttribute : Attribute
+{
+    public MyObjectArrayAttribute(object[] values)
+    {
+        Values = values;
+    }
+
+    public object[] Values { get; }
+}


### PR DESCRIPTION
Object type attributes were serialized without a type tag which caused BadFormatException when trying to read these attributes in runtime